### PR TITLE
IPv6 link-local prefix is fe80::/64, not /10

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -678,7 +678,7 @@ module V6 = struct
     let of_addr ip = make 128 ip
 
     let global_unicast_001  = make  3 (ip 0x2000 0 0 0 0 0 0 0)
-    let link                = make 10 (ip 0xfe80 0 0 0 0 0 0 0)
+    let link                = make 64 (ip 0xfe80 0 0 0 0 0 0 0)
     let unique_local        = make  7 (ip 0xfc00 0 0 0 0 0 0 0)
     let multicast           = make  8 (ip 0xff00 0 0 0 0 0 0 0)
     let ipv4_mapped         = make 96 (ip 0 0 0 0 0 0xffff 0 0)

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -432,7 +432,7 @@ module V6 : sig
     (** The Unique Local Unicast (ULA), fc00::/7. *)
     val unique_local       : t
 
-    (** Link-Local Unicast, fe80::/10. *)
+    (** Link-Local Unicast, fe80::/64. *)
     val link               : t
 
     (** The multicast network, ff00::/8. *)

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -453,7 +453,7 @@ module Test_v6 = struct
   let test_prefix_bits () =
     let pairs = V6.Prefix.([
       global_unicast_001, 3;
-      link,              10;
+      link,              64;
       unique_local,       7;
       multicast,          8;
       ipv4_mapped,       96;


### PR DESCRIPTION
See RFC 4291, 2.5.6:
http://tools.ietf.org/html/rfc4291#section-2.5.6
