### PR TITLE
add ppx_deriving dependency

### DIFF
--- a/opam
+++ b/opam
@@ -30,6 +30,7 @@ depends: [
   "topkg" {build}
   "base-bytes"
   "sexplib"
+  "ppx_deriving"
   "ppx_sexp_conv"
   "ounit" {test}
 ]


### PR DESCRIPTION
New version of Core makes ppx_deriving optional. This breaks ocaml-ipaddr.