### PR TITLE
Add sexplib dependency to opam

### DIFF
--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -27,7 +27,7 @@ depends: [
   "base-bytes"
   "ppx_sexp_conv" {build & >="v0.9.0"}
   "sexplib"
+  "base-unix"
   "ounit" {test}
 ]
-depopts: [ "base-unix" ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
This is used directly so we shouldn't rely on ppx_sexp_conv to pull it
transitively.

A point release with this chnage would be appreciated.