### PR TITLE
[wip] rel 3.0.0 with soft sexp dependency and result types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 _build
 *.install
 **/*.merlin
-
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
    - PINS="macaddr:."
    - REVDEPS="true"
  matrix:
-   - DISTRO=debian-testing OCAML_VERSION=4.03
    - DISTRO=debian-stable OCAML_VERSION=4.04
    - DISTRO=ubuntu OCAML_VERSION=4.05
    - DISTRO=alpine OCAML_VERSION=4.06

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash ./.travis-docker.sh
 env:
  global:
-   - PACKAGE="ipaddr macaddr"
+   - PACKAGE="ipaddr"
+   - PINS="macaddr:."
    - REVDEPS="true"
  matrix:
    - DISTRO=debian-testing OCAML_VERSION=4.03

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash ./.travis-docker.sh
 env:
  global:
-   - PACKAGE="ipaddr"
+   - PACKAGE="ipaddr macaddr"
    - REVDEPS="true"
  matrix:
    - DISTRO=debian-testing OCAML_VERSION=4.03

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 3.0.0
+
+* Remove the sexp serialisers from the main interface in favour
+  of `pp` functions.  Use the `Ipaddr_sexp` module if you still
+  need a sexp serialiser.
+* Remove `pp_hum` which was deprecated in 2.9.0.
+
 ## 2.9.0 (2018-12-11)
 
 * Add `pp` functions for prettyprinting and deprecate `pp_hum` variants.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,15 @@ of the library.
 * Break out the `Macaddr` module into a separate opam package so
   that the `Ipaddr` module can be wrapped.
 
-
 * Replace all the `of_string/bytes` functions that formerly returned
   option types with the `Rresult` result types instead. This stops
-  the 
+  the cause of the exception from being swallowed, and the error
+  message in the new functions can be displayed usefully.
 
 * Remove `pp_hum` which was deprecated in 2.9.0.
+
+* Minimum OCaml version is now 4.04.0+
+
 ## 2.9.0 (2018-12-11)
 
 * Add `pp` functions for prettyprinting and deprecate `pp_hum` variants.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,35 @@ of the library.
   of `pp` functions.  Use the `Ipaddr_sexp` module if you still
   need a sexp serialiser.
 
+  To use these with ppx-based derivers, simply replace the
+  reference to the `Ipaddr` type definition with `Ipaddr_sexp`.
+  That will import the sexp-conversion functions, and the actual
+  type definitions are simply aliases to the corresponding type
+  within `Ipaddr`.  For example, you might do:
+
+  ```
+  type t = {
+    ip: Ipaddr_sexp.t;
+    mac: Macaddr_sexp.t;
+  } [@@deriving sexp]
+  ```
+
+  The actual types of the records will be aliases to the main
+  library types, and there will be two new functions available
+  as converters.  The signature after ppx has run will be:
+
+  ```
+  type t = {
+    ip: Ipaddr.t;
+    mac: Macaddr.t;
+  }
+  val sexp_of_t : t -> Sexplib0.t
+  val t_of_sexp : Sexplib0.t -> t
+  ```
+
 * Break out the `Macaddr` module into a separate opam package so
-  that the `Ipaddr` module can be wrapped.
+  that the `Ipaddr` module can be wrapped.  Use the `macaddr`
+  opam library now if you need just the MAC address functionality.
 
 * Replace all the `of_string/bytes` functions that formerly returned
   option types with the `Rresult` result types instead. This stops
@@ -18,7 +45,12 @@ of the library.
 
 * Remove `pp_hum` which was deprecated in 2.9.0.
 
-* Minimum OCaml version is now 4.04.0+
+* Sexplib0 is now used which is more lightweight tha the full
+  Sexplib library. Minimum OCaml version is now 4.04.0+ as a result
+  of this dependency.
+
+* Improvements to the ocamldoc formatting strings for better
+  layout and odoc compatibility.
 
 ## 2.9.0 (2018-12-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   of `pp` functions.  Use the `Ipaddr_sexp` module if you still
   need a sexp serialiser.
 * Remove `pp_hum` which was deprecated in 2.9.0.
+* Break out the `Macaddr` module into a separate opam package so
+  that the `Ipaddr` module can be wrapped.
 
 ## 2.9.0 (2018-12-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,22 @@
 ## 3.0.0
 
+This release features several backwards incompatible changes,
+but ones that should increase the portability and robustness
+of the library.
+
 * Remove the sexp serialisers from the main interface in favour
   of `pp` functions.  Use the `Ipaddr_sexp` module if you still
   need a sexp serialiser.
-* Remove `pp_hum` which was deprecated in 2.9.0.
+
 * Break out the `Macaddr` module into a separate opam package so
   that the `Ipaddr` module can be wrapped.
 
+
+* Replace all the `of_string/bytes` functions that formerly returned
+  option types with the `Rresult` result types instead. This stops
+  the 
+
+* Remove `pp_hum` which was deprecated in 2.9.0.
 ## 2.9.0 (2018-12-11)
 
 * Add `pp` functions for prettyprinting and deprecate `pp_hum` variants.

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ all:
 test:
 	dune runtest
 
+doc:
+	dune build @doc
+
 clean:
 	dune clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ipaddr: IP (and MAC) address manipulation
 
-A library for manipulation of IP (and MAC) address representations.
+A library for manipulation of IP and MAC address representations.
 
 Features:
 
@@ -19,3 +19,14 @@ Features:
  * MAC-48 (Ethernet) address support
  * `Macaddr` is a `Map.OrderedType`
  * All types have sexplib serializers/deserializers
+
+## Usage
+
+There are the following ocamlfind libraries included as part of this repository:
+
+- `ipaddr`: The `Ipaddr` module for IPv4/6 manipulation.
+- `macaddr`: The `Macaddr` module for MAC address manipulation.
+- `ipaddr.top`: Toplevel printers for Ipaddr.
+- `macaddr.top`: Toplevel printers for Macaddr.
+- `ipaddr.sexp`: S-expression converters for Ipaddr.
+- `macaddr.sexp`: S-expression converters for Macaddr.

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.6)
+(lang dune 1.0)

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.0)
+(name ipaddr)

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -29,10 +29,10 @@ bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "base-bytes"
-  "base-unix"
   "macaddr"
+  "sexplib0"
   "ounit" {with-test}
+  "ppx_sexp_conv" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -30,9 +30,8 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
   "base-bytes"
-  "ppx_sexp_conv" {>="v0.9.0"}
-  "sexplib"
   "base-unix"
+  "macaddr"
   "ounit" {with-test}
 ]
 build: [

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.0"}
   "dune" {build}
   "macaddr"
   "sexplib0"

--- a/lib/dune
+++ b/lib/dune
@@ -1,10 +1,13 @@
 (library
  (name        ipaddr)
  (public_name ipaddr)
- (modules ipaddr macaddr)
- (wrapped false)
- (preprocess (pps ppx_sexp_conv))
- (libraries sexplib))
+ (modules ipaddr)
+ (libraries macaddr))
+
+(library
+ (name        macaddr)
+ (public_name macaddr)
+ (modules macaddr))
 
 (library
  (name        ipaddr_unix)

--- a/lib/dune
+++ b/lib/dune
@@ -5,6 +5,12 @@
  (libraries macaddr))
 
 (library
+ (name        ipaddr_sexp)
+ (public_name ipaddr.sexp)
+ (modules ipaddr_sexp)
+ (libraries ipaddr sexplib0))
+
+(library
  (name        macaddr)
  (public_name macaddr)
  (modules macaddr))

--- a/lib/dune
+++ b/lib/dune
@@ -5,15 +5,21 @@
  (libraries macaddr))
 
 (library
+ (name        macaddr)
+ (public_name macaddr)
+ (modules macaddr))
+
+(library
  (name        ipaddr_sexp)
  (public_name ipaddr.sexp)
  (modules ipaddr_sexp)
  (libraries ipaddr sexplib0))
 
 (library
- (name        macaddr)
- (public_name macaddr)
- (modules macaddr))
+ (name        macaddr_sexp)
+ (public_name macaddr.sexp)
+ (modules macaddr_sexp)
+ (libraries macaddr sexplib0))
 
 (library
  (name        ipaddr_unix)
@@ -25,4 +31,10 @@
  (name        ipaddr_top)
  (public_name ipaddr.top)
  (modules ipaddr_top)
- (libraries ipaddr compiler-libs))
+ (libraries macaddr.top ipaddr compiler-libs))
+
+(library
+ (name        macaddr_top)
+ (public_name macaddr.top)
+ (modules macaddr_top)
+ (libraries macaddr compiler-libs))

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -15,9 +15,7 @@
  *
  *)
 
-open Sexplib.Std
-
-exception Parse_error of string * string [@@deriving sexp]
+exception Parse_error of string * string
 
 type scope =
 | Point
@@ -27,7 +25,6 @@ type scope =
 | Site
 | Organization
 | Global
-[@@deriving sexp]
 
 let (~|) = Int32.of_int
 let (|~) = Int32.to_int
@@ -147,6 +144,7 @@ module V4 = struct
     let x = of_string_raw s o in
     expect_end s o;
     x
+
   let of_string s = try Some (of_string_exn s) with _ -> None
 
   let to_buffer b i =
@@ -159,14 +157,6 @@ module V4 = struct
 
   let pp ppf i =
     Format.fprintf ppf "%s" (to_string i)
-
-  let sexp_of_t i =
-    Sexplib.Sexp.Atom (to_string i)
-
-  let t_of_sexp i =
-    match i with
-    | Sexplib.Sexp.Atom i -> of_string_exn i
-    | _ -> raise (Failure "Ipaddr.V4.t: Unexpected non-atom in sexp")
 
   (* Byte conversion *)
 
@@ -237,8 +227,8 @@ module V4 = struct
   let routers     = make 224   0   0   2
 
   module Prefix = struct
-    type addr = t [@@deriving sexp]
-    type t = addr * int [@@deriving sexp]
+    type addr = t
+    type t = addr * int
 
     let compare (pre,sz) (pre',sz') =
       let c = compare pre pre' in
@@ -599,14 +589,6 @@ module V6 = struct
   let pp ppf i =
     Format.fprintf ppf "%s" (to_string i)
 
-  let sexp_of_t i =
-    Sexplib.Sexp.Atom (to_string i)
-
-  let t_of_sexp i =
-    match i with
-    | Sexplib.Sexp.Atom i -> of_string_exn i
-    | _ -> raise (Failure "Ipaddr.V6.t: Unexpected non-atom in sexp")
-
   (* byte conversion *)
 
   let of_bytes_raw bs o = (* TODO : from cstruct *)
@@ -691,8 +673,8 @@ module V6 = struct
   let site_routers      = make 0xff05 0 0 0 0 0 0 2
 
   module Prefix = struct
-    type addr = t [@@deriving sexp]
-    type t = addr * int [@@deriving sexp]
+    type addr = t
+    type t = addr * int
 
     let compare (pre,sz) (pre',sz') =
       let c = compare pre pre' in
@@ -835,8 +817,8 @@ module V6 = struct
   let is_private i = (scope i) <> Global
 end
 
-type ('v4,'v6) v4v6 = V4 of 'v4 | V6 of 'v6 [@@deriving sexp]
-type t = (V4.t,V6.t) v4v6 [@@deriving sexp]
+type ('v4,'v6) v4v6 = V4 of 'v4 | V6 of 'v6
+type t = (V4.t,V6.t) v4v6
 
 let compare a b = match a,b with
   | V4 a, V4 b -> V4.compare a b
@@ -915,8 +897,8 @@ module Prefix = struct
     let to_v6 = to_v6
   end
 
-  type addr = t [@@deriving sexp]
-  type t = (V4.Prefix.t,V6.Prefix.t) v4v6 [@@deriving sexp]
+  type addr = t
+  type t = (V4.Prefix.t,V6.Prefix.t) v4v6
 
   let compare a b = match a,b with
     | V4 a , V4 b -> V4.Prefix.compare a b

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -194,8 +194,8 @@ module V4 = struct
   let of_int16 (a,b) = (~| a <|< 16) ||| (~| b)
   let to_int16 a = ((|~) (a >|> 16), (|~) (a &&& 0xFF_FF_l))
 
-  (** MAC *)
-  (** {{:http://tools.ietf.org/html/rfc1112#section-6.2}RFC 1112}. *)
+  (* MAC *)
+  (* {{:http://tools.ietf.org/html/rfc1112#section-6.2}RFC 1112}. *)
   let multicast_to_mac i =
     let macb = Bytes.create 6 in
     Bytes.set macb 0 (Char.chr 0x01);
@@ -610,8 +610,8 @@ module V6 = struct
     to_bytes_raw i bs 0;
     Bytes.to_string bs
 
-  (** MAC *)
-  (** {{:https://tools.ietf.org/html/rfc2464#section-7}RFC 2464}. *)
+  (* MAC *)
+  (* {{:https://tools.ietf.org/html/rfc2464#section-7}RFC 2464}. *)
   let multicast_to_mac i =
     let (_,_,_,i) = to_int32 i in
     let macb = Bytes.create 6 in

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -160,8 +160,6 @@ module V4 = struct
   let pp ppf i =
     Format.fprintf ppf "%s" (to_string i)
 
-  let pp_hum = pp
-
   let sexp_of_t i =
     Sexplib.Sexp.Atom (to_string i)
 
@@ -306,8 +304,6 @@ module V4 = struct
 
     let pp ppf i =
       Format.fprintf ppf "%s" (to_string i)
-
-    let pp_hum = pp
 
     let to_address_buffer buf ((_,sz) as subnet) addr =
       to_buffer buf (network_address subnet addr,sz)
@@ -603,8 +599,6 @@ module V6 = struct
   let pp ppf i =
     Format.fprintf ppf "%s" (to_string i)
 
-  let pp_hum = pp
-
   let sexp_of_t i =
     Sexplib.Sexp.Atom (to_string i)
 
@@ -769,8 +763,6 @@ module V6 = struct
     let pp ppf i =
       Format.fprintf ppf "%s" (to_string i)
 
-    let pp_hum = pp
-
     let to_address_buffer buf ((_,sz) as subnet) addr =
       to_buffer buf (network_address subnet addr,sz)
 
@@ -862,8 +854,6 @@ let to_buffer buf = function
 
 let pp ppf i =
       Format.fprintf ppf "%s" (to_string i)
-
-let pp_hum = pp
 
 let of_string_raw s offset =
   let len = String.length s in
@@ -994,6 +984,4 @@ module Prefix = struct
 
   let pp ppf i =
     Format.fprintf ppf "%s" (to_string i)
-
-  let pp_hum = pp
 end

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -20,7 +20,7 @@
     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}} *)
 
 (** Raised when parsing of IP address syntax fails. *)
-exception Parse_error of string * string [@@deriving sexp]
+exception Parse_error of string * string
 
 (** Type of ordered address scope classifications *)
 type scope =
@@ -31,12 +31,11 @@ type scope =
 | Site
 | Organization
 | Global
-[@@deriving sexp]
 
 (** A collection of functions for IPv4 addresses. *)
 module V4 : sig
   (** Type of the internet protocol v4 address of a host *)
-  type t [@@deriving sexp]
+  type t
 
   (** Converts the low bytes of four int values into an abstract {! V4.t }. *)
   val make : int -> int -> int -> int -> t
@@ -67,13 +66,6 @@ module V4 : sig
   (** [pp f ipv4] outputs a human-readable representation of [ipv4] to
       the formatter [f]. *)
   val pp : Format.formatter -> t -> unit
-
-  (** [pp_hum f ipv4] outputs a human-readable representation of [ipv4] to
-      the formatter [f].
-      @deprecated This function will be deprecated in a future version of this
-      library. Please use pp instead. *)
-  val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.deprecated "Please use Ipaddr.V4.pp instead."]
 
   (** {3 Bytestring conversion} *)
 
@@ -148,10 +140,10 @@ module V4 : sig
 
   (** A module for manipulating IPv4 network prefixes. *)
   module Prefix : sig
-    type addr = t [@@deriving sexp]
+    type addr = t
 
     (** Type of a internet protocol subnet *)
-    type t [@@deriving sexp]
+    type t
 
     (** [mask n] is the pseudo-address of an [n] bit subnet mask. *)
     val mask : int -> addr
@@ -184,13 +176,6 @@ module V4 : sig
     (** [pp f prefix] outputs a human-readable representation of [prefix]
         to the formatter [f]. *)
     val pp : Format.formatter -> t -> unit
-
-    (** [pp_hum f prefix] outputs a human-readable representation of [prefix]
-        to the formatter [f].
-        @deprecated This function will be deprecated in a future version of this
-        library. Please use pp instead. *)
-    val pp_hum : Format.formatter -> t -> unit
-    [@@ocaml.deprecated "Please use Ipaddr.V4.Prefix.pp instead."]
 
     (** [of_address_string_exn cidr_addr] is the address and prefix
         represented by [cidr_addr]. Raises [Parse_error] if [cidr_addr] is not
@@ -294,7 +279,7 @@ end
 (** A collection of functions for IPv6 addresses. *)
 module V6 : sig
   (** Type of the internet protocol v6 address of a host *)
-  type t [@@deriving sexp]
+  type t
 
   (** Converts the low bytes of eight int values into an abstract
       {! V6.t }. *)
@@ -326,13 +311,6 @@ module V6 : sig
   (** [pp f ipv6] outputs a human-readable representation of [ipv6] to
       the formatter [f]. *)
   val pp : Format.formatter -> t -> unit
-
-  (** [pp_hum f ipv6] outputs a human-readable representation of [ipv6] to
-      the formatter [f].
-      @deprecated This function will be deprecated in a future version of this
-      library. Please use pp instead. *)
-  val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.deprecated "Please use Ipaddr.V6.pp instead."]
 
   (** {3 Bytestring conversion} *)
 
@@ -412,10 +390,10 @@ module V6 : sig
 
   (** A module for manipulating IPv6 network prefixes. *)
   module Prefix : sig
-    type addr = t [@@deriving sexp]
+    type addr = t
 
     (** Type of a internet protocol subnet *)
-    type t [@@deriving sexp]
+    type t
 
     (** [mask n] is the pseudo-address of an [n] bit subnet mask. *)
     val mask : int -> addr
@@ -448,13 +426,6 @@ module V6 : sig
     (** [pp f prefix] outputs a human-readable representation of [prefix]
         to the formatter [f]. *)
     val pp : Format.formatter -> t -> unit
-
-    (** [pp_hum f prefix] outputs a human-readable representation of [prefix]
-        to the formatter [f].
-        @deprecated This function will be deprecated in a future version of this
-        library. Please use pp instead. *)
-    val pp_hum : Format.formatter -> t -> unit
-    [@@ocaml.deprecated "Please use Ipaddr.V6.Prefix.pp instead."]
 
     (** [of_address_string_exn cidr_addr] is the address and prefix
         represented by [cidr_addr]. Raises [Parse_error] if [cidr_addr] is not
@@ -553,10 +524,10 @@ module V6 : sig
 end
 
 (** Type of either an IPv4 value or an IPv6 value *)
-type ('v4,'v6) v4v6 = V4 of 'v4 | V6 of 'v6 [@@deriving sexp]
+type ('v4,'v6) v4v6 = V4 of 'v4 | V6 of 'v6
 
 (** Type of any IP address *)
-type t = (V4.t,V6.t) v4v6 [@@deriving sexp]
+type t = (V4.t,V6.t) v4v6
 
 (** [to_string addr] is the text string representation of [addr]. *)
 val to_string : t -> string
@@ -568,13 +539,6 @@ val to_buffer : Buffer.t -> t -> unit
 (** [pp f ip] outputs a human-readable representation of [ip] to the
     formatter [f]. *)
 val pp : Format.formatter -> t -> unit
-
-(** [pp_hum f ip] outputs a human-readable representation of [ip] to the
-    formatter [f].
-    @deprecated This function will be deprecated in a future version of this
-    library. Please use pp instead. *)
-val pp_hum : Format.formatter -> t -> unit
-[@@ocaml.deprecated "Please use Ipaddr.pp instead."]
 
 (** [of_string_exn s] parses [s] as an IPv4 or IPv6 address.
     Raises [Parse_error] if [s] is not a valid string representation of an IP
@@ -628,10 +592,10 @@ val multicast_to_mac : t -> Macaddr.t
 val to_domain_name : t -> string list
 
 module Prefix : sig
-  type addr = t [@@deriving sexp]
+  type addr = t
 
   (** Type of a internet protocol subnet *)
-  type t = (V4.Prefix.t, V6.Prefix.t) v4v6 [@@deriving sexp]
+  type t = (V4.Prefix.t, V6.Prefix.t) v4v6
 
   (** [to_string subnet] is the text string representation of [subnet]. *)
   val to_string : t -> string
@@ -643,13 +607,6 @@ module Prefix : sig
   (** [pp f subnet] outputs a human-readable representation of [subnet]
       to the formatter [f]. *)
   val pp : Format.formatter -> t -> unit
-
-  (** [pp_hum f subnet] outputs a human-readable representation of [subnet]
-      to the formatter [f].
-      @deprecated This function will be deprecated in a future version of this
-      library. Please use pp instead. *)
-  val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.deprecated "Please use Ipaddr.Prefix.pp instead."]
 
   (** [of_string_exn cidr] is the subnet prefix represented by the CIDR
       string, [cidr]. Raises [Parse_error] if [cidr] is not a valid

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -338,17 +338,20 @@ module V6 : sig
 
   (** [of_int64 (ho, lo)] is the IPv6 address represented by two int64. *)
   val of_int64 : int64 * int64 -> t
+
   (** [to_int64 ipv6] is the 128-bit packed encoding of [ipv6]. *)
   val to_int64 : t -> int64 * int64
 
   (** [of_int32 (a, b, c, d)] is the IPv6 address represented by four int32. *)
   val of_int32 : int32 * int32 * int32 * int32 -> t
+
   (** [to_int32 ipv6] is the 128-bit packed encoding of [ipv6]. *)
   val to_int32 : t -> int32 * int32 * int32 * int32
 
   (** [of_int16 (a, b, c, d, e, f, g, h)] is the IPv6 address represented by
       eight 16-bit int. *)
   val of_int16 : int * int * int * int * int * int * int * int -> t
+
   (** [to_int16 ipv6] is the 128-bit packed encoding of [ipv6]. *)
   val to_int16 : t -> int * int * int * int * int * int * int * int
 

--- a/lib/ipaddr_sexp.ml
+++ b/lib/ipaddr_sexp.ml
@@ -1,0 +1,93 @@
+(*
+ * Copyright (c) 2018 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Sexplib0
+
+let of_sexp fn = function
+  | Sexp.List _ -> failwith "expecting sexp atom"
+  | Sexp.Atom s -> (
+    match fn s with Ok r -> r | Error (`Msg msg) -> failwith msg )
+
+let to_sexp fn t = Sexp.Atom (fn t)
+
+module V4 = struct
+  module I = Ipaddr.V4
+
+  type t = I.t
+
+  let sexp_of_t = to_sexp I.to_string
+
+  let t_of_sexp = of_sexp I.of_string
+
+  let compare = I.compare
+
+  module Prefix = struct
+    module I = Ipaddr.V4.Prefix
+
+    type addr = I.addr
+
+    type t = I.t
+
+    let sexp_of_t = to_sexp I.to_string
+
+    let t_of_sexp = of_sexp I.of_string
+
+    let compare = I.compare
+  end
+end
+
+module V6 = struct
+  module I = Ipaddr.V6
+
+  type t = I.t
+
+  let sexp_of_t = to_sexp I.to_string
+
+  let t_of_sexp = of_sexp I.of_string
+
+  let compare = I.compare
+
+  module Prefix = struct
+    module I = Ipaddr.V6.Prefix
+
+    type addr = I.addr
+
+    type t = I.t
+
+    let sexp_of_t = to_sexp I.to_string
+
+    let t_of_sexp = of_sexp I.of_string
+
+    let compare = I.compare
+  end
+end
+
+module I = Ipaddr
+
+type t = I.t
+
+let sexp_of_t = to_sexp I.to_string
+
+let t_of_sexp = of_sexp I.of_string
+
+let compare = I.compare
+
+type scope = I.scope
+
+let sexp_of_scope = to_sexp I.string_of_scope
+
+let scope_of_sexp = of_sexp I.scope_of_string

--- a/lib/ipaddr_sexp.mli
+++ b/lib/ipaddr_sexp.mli
@@ -1,0 +1,76 @@
+(*
+ * Copyright (c) 2018 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+(** serialisers to and from {!Ipaddr} and s-expression {!Sexplib0} format *)
+
+type t = Ipaddr.t
+
+val sexp_of_t : Ipaddr.t -> Sexplib0.Sexp.t
+
+val t_of_sexp : Sexplib0.Sexp.t -> Ipaddr.t
+
+val compare : Ipaddr.t -> Ipaddr.t -> int
+
+type scope = Ipaddr.scope
+
+val sexp_of_scope : Ipaddr.scope -> Sexplib0.Sexp.t
+
+val scope_of_sexp : Sexplib0.Sexp.t -> Ipaddr.scope
+
+module V4 : sig
+  type t = Ipaddr.V4.t
+
+  val sexp_of_t : Ipaddr.V4.t -> Sexplib0.Sexp.t
+
+  val t_of_sexp : Sexplib0.Sexp.t -> Ipaddr.V4.t
+
+  val compare : Ipaddr.V4.t -> Ipaddr.V4.t -> int
+
+  module Prefix : sig
+    type addr = Ipaddr.V4.Prefix.addr
+
+    type t = Ipaddr.V4.Prefix.t
+
+    val sexp_of_t : Ipaddr.V4.Prefix.t -> Sexplib0.Sexp.t
+
+    val t_of_sexp : Sexplib0.Sexp.t -> Ipaddr.V4.Prefix.t
+
+    val compare : Ipaddr.V4.Prefix.t -> Ipaddr.V4.Prefix.t -> int
+  end
+end
+
+module V6 : sig
+  type t = Ipaddr.V6.t
+
+  val sexp_of_t : Ipaddr.V6.t -> Sexplib0.Sexp.t
+
+  val t_of_sexp : Sexplib0.Sexp.t -> Ipaddr.V6.t
+
+  val compare : Ipaddr.V6.t -> Ipaddr.V6.t -> int
+
+  module Prefix : sig
+    type addr = Ipaddr.V6.Prefix.addr
+
+    type t = Ipaddr.V6.Prefix.t
+
+    val sexp_of_t : Ipaddr.V6.Prefix.t -> Sexplib0.Sexp.t
+
+    val t_of_sexp : Sexplib0.Sexp.t -> Ipaddr.V6.Prefix.t
+
+    val compare : Ipaddr.V6.Prefix.t -> Ipaddr.V6.Prefix.t -> int
+  end
+end

--- a/lib/ipaddr_sexp.mli
+++ b/lib/ipaddr_sexp.mli
@@ -15,7 +15,32 @@
  *
  *)
 
-(** serialisers to and from {!Ipaddr} and s-expression {!Sexplib0} format *)
+(** serialisers to and from {!Ipaddr} and s-expression {!Sexplib0} format 
+  
+  To use these with ppx-based derivers, simply replace the reference to the
+  {!Ipaddr} type definition with {!Ipaddr_sexp} instead. That will import the
+  sexp-conversion functions, and the actual type definitions are simply aliases
+  to the corresponding type within {!Ipaddr}.  For example, you might do:
+
+  {[
+    type t = {
+      ip: Ipaddr_sexp.t;
+      mac: Macaddr_sexp.t;
+    } [@@deriving sexp]
+  ]}
+
+  The actual types of the records will be aliases to the main library types,
+  and there will be two new functions available as converters.
+
+  {[
+     type t = {
+       ip: Ipaddr.t;
+       mac: Macaddr.t;
+     }
+     val sexp_of_t : t -> Sexplib0.t
+     val t_of_sexp : Sexplib0.t -> t
+  ]}
+*)
 
 type t = Ipaddr.t
 

--- a/lib/macaddr.ml
+++ b/lib/macaddr.ml
@@ -19,6 +19,10 @@ exception Parse_error of string * string
 
 let need_more x = Parse_error ("not enough data", x)
 
+let try_with_result fn a =
+  try Ok (fn a)
+  with Parse_error (msg, _) -> Error (`Msg ("Macaddr: " ^ msg))
+
 type t = Bytes.t (* length 6 only *)
 
 let compare = Bytes.compare
@@ -29,7 +33,7 @@ let of_bytes_exn x =
   then raise (Parse_error ("MAC is exactly 6 bytes", x))
   else Bytes.of_string x
 
-let of_bytes x = try Some (of_bytes_exn x) with _ -> None
+let of_bytes x = try_with_result of_bytes_exn x
 
 let int_of_hex_char c =
   let c = int_of_char (Char.uppercase_ascii c) - 48 in
@@ -92,7 +96,7 @@ let parse_sextuple s i =
 (* Read a MAC address colon-separated string *)
 let of_string_exn x = parse_sextuple x (ref 0)
 
-let of_string x = try Some (of_string_exn x) with _ -> None
+let of_string x = try_with_result of_string_exn x
 
 let chri x i = Char.code (Bytes.get x i)
 

--- a/lib/macaddr.ml
+++ b/lib/macaddr.ml
@@ -15,9 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Sexplib.Std
-
-exception Parse_error of string * string [@@deriving sexp]
+exception Parse_error of string * string
 
 let need_more x = Parse_error ("not enough data", x)
 
@@ -111,13 +109,6 @@ let to_bytes x = Bytes.to_string x
 
 let pp ppf i =
   Format.fprintf ppf "%s" (to_string i)
-
-let sexp_of_t m = Sexplib.Sexp.Atom (to_string m)
-
-let t_of_sexp m =
-  match m with
-  | Sexplib.Sexp.Atom m -> of_string_exn m
-  | _ -> raise (Failure "Macaddr.t: Unexpected non-atom in sexp")
 
 let broadcast = Bytes.make 6 '\255'
 

--- a/lib/macaddr.mli
+++ b/lib/macaddr.mli
@@ -49,14 +49,14 @@ val of_string : string ->  (t, [> `Msg of string]) result
 val to_bytes : t -> string
 
 (** [to_string ?(sep=':') mac_addr] is the [sep]-separated string representation
-    of [mac_addr], i.e. xx:xx:xx:xx:xx:xx. *)
+    of [mac_addr], i.e. [xx:xx:xx:xx:xx:xx]. *)
 val to_string : ?sep:char -> t -> string
 
 (** [pp f mac_addr] outputs a human-readable representation of [mac_addr] to
     the formatter [f]. *)
 val pp : Format.formatter -> t -> unit
 
-(** [broadcast] is ff:ff:ff:ff:ff:ff. *)
+(** [broadcast] is [ff:ff:ff:ff:ff:ff]. *)
 val broadcast : t
 
 (** [make_local bytegen] creates a unicast, locally administered MAC

--- a/lib/macaddr.mli
+++ b/lib/macaddr.mli
@@ -18,14 +18,15 @@
 
     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}} *)
 
-(** Raised when parsing of MAC address syntax fails. *)
+(** [Parse_error (err,packet)] is raised when parsing of the MAC
+    address syntax fails. [err] contains a human-readable error
+    and [packet] is the original octet list that failed to parse. *)
 exception Parse_error of string * string
 
 (** Type of the hardware address (MAC) of an ethernet interface. *)
 type t
 
-(** Functions converting MAC addresses to bytes/string and vice
-    versa. *)
+(** {2 Functions converting MAC addresses to/from bytes/string} *)
 
 (** [of_bytes_exn buf] is the hardware address extracted from
     [buf]. Raises [Parse_error] if [buf] has not length 6. *)
@@ -33,7 +34,7 @@ val of_bytes_exn : string -> t
 
 (** Same as above but returns an option type instead of raising an
     exception. *)
-val of_bytes : string -> t option
+val of_bytes : string -> (t, [> `Msg of string]) result
 
 (** [of_string_exn mac_string] is the hardware address represented by
     [mac_string]. Raises [Parse_error] if [mac_string] is not a
@@ -42,7 +43,7 @@ val of_string_exn : string -> t
 
 (** Same as above but returns an option type instead of raising an
     exception. *)
-val of_string : string -> t option
+val of_string : string ->  (t, [> `Msg of string]) result
 
 (** [to_bytes mac_addr] is a string of size 6 encoding [mac_addr]. *)
 val to_bytes : t -> string

--- a/lib/macaddr.mli
+++ b/lib/macaddr.mli
@@ -19,10 +19,10 @@
     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}} *)
 
 (** Raised when parsing of MAC address syntax fails. *)
-exception Parse_error of string * string [@@deriving sexp]
+exception Parse_error of string * string
 
 (** Type of the hardware address (MAC) of an ethernet interface. *)
-type t [@@deriving sexp]
+type t
 
 (** Functions converting MAC addresses to bytes/string and vice
     versa. *)

--- a/lib/macaddr_sexp.ml
+++ b/lib/macaddr_sexp.ml
@@ -1,0 +1,33 @@
+(*
+ * Copyright (c) 2018 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Sexplib0
+
+let of_sexp fn = function
+  | Sexp.List _ -> failwith "expecting sexp atom"
+  | Sexp.Atom s -> (
+    match fn s with Ok r -> r | Error (`Msg msg) -> failwith msg )
+
+let to_sexp fn t = Sexp.Atom (fn t)
+
+type t = Macaddr.t
+
+let sexp_of_t = to_sexp Macaddr.to_string
+
+let t_of_sexp = of_sexp Macaddr.of_string
+
+let compare = Macaddr.compare

--- a/lib/macaddr_sexp.mli
+++ b/lib/macaddr_sexp.mli
@@ -15,7 +15,32 @@
  *
  *)
 
-(** serialisers to and from {!Macaddr} and s-expression {!Sexplib0} format *)
+(** serialisers to and from {!Macaddr} and s-expression {!Sexplib0} format
+
+  To use these with ppx-based derivers, simply replace the reference to the
+  {!Macaddr} type definition with {!Macaddr_sexp} instead. That will import the
+  sexp-conversion functions, and the actual type definitions are simply aliases
+  to the corresponding type within {!Ipaddr}.  For example, you might do:
+
+  {[
+    type t = {
+      ip: Ipaddr_sexp.t;
+      mac: Macaddr_sexp.t;
+    } [@@deriving sexp]
+  ]}
+
+  The actual types of the records will be aliases to the main library types,
+  and there will be two new functions available as converters.
+
+  {[
+     type t = {
+       ip: Ipaddr.t;
+       mac: Macaddr.t;
+     }
+     val sexp_of_t : t -> Sexplib0.t
+     val t_of_sexp : Sexplib0.t -> t
+  ]}
+*)
 
 type t = Macaddr.t
 

--- a/lib/macaddr_sexp.mli
+++ b/lib/macaddr_sexp.mli
@@ -1,0 +1,27 @@
+(*
+ * Copyright (c) 2018 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+(** serialisers to and from {!Macaddr} and s-expression {!Sexplib0} format *)
+
+type t = Macaddr.t
+
+val sexp_of_t : Macaddr.t -> Sexplib0.Sexp.t
+
+val t_of_sexp : Sexplib0.Sexp.t -> Macaddr.t
+
+val compare : Macaddr.t -> Macaddr.t -> int
+

--- a/lib/macaddr_top.ml
+++ b/lib/macaddr_top.ml
@@ -1,0 +1,19 @@
+let printers = [
+  "Macaddr.pp";
+]
+
+let eval_string
+      ?(print_outcome = false) ?(err_formatter = Format.err_formatter) str =
+  let lexbuf = Lexing.from_string str in
+  let phrase = !Toploop.parse_toplevel_phrase lexbuf in
+  Toploop.execute_phrase print_outcome err_formatter phrase
+
+let rec install_printers = function
+  | [] -> true
+  | printer :: printers ->
+      let cmd = Printf.sprintf "#install_printer %s;;" printer in
+      eval_string cmd && install_printers printers
+
+let () =
+  if not (install_printers printers) then
+    Format.eprintf "Problem installing Macaddr-printers@."

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,6 +1,6 @@
 (executables
  (names test_ipaddr test_macaddr)
- (libraries ipaddr oUnit))
+ (libraries ipaddr oUnit ipaddr.sexp))
 
 (alias
  (name    runtest)

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,6 +1,12 @@
 (executables
- (names test_ipaddr test_macaddr)
+ (names test_ipaddr test_macaddr test_ppx)
+ (preprocess (pps ppx_sexp_conv))
  (libraries ipaddr oUnit ipaddr.sexp macaddr.sexp))
+
+(alias
+ (name    runtest)
+ (deps    test_ppx.exe)
+ (action  (run %{deps})))
 
 (alias
  (name    runtest)

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,6 +1,6 @@
 (executables
  (names test_ipaddr test_macaddr)
- (libraries ipaddr oUnit ipaddr.sexp))
+ (libraries ipaddr oUnit ipaddr.sexp macaddr.sexp))
 
 (alias
  (name    runtest)

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -44,7 +44,7 @@ module Test_v4 = struct
       let os = V4.of_string_exn addr in
       let ts = V4.to_string os in
       assert_equal ~msg:addr ts rt;
-      let os = V4.t_of_sexp (V4.sexp_of_t os) in
+      let os = Ipaddr_sexp.(V4.t_of_sexp (V4.sexp_of_t os)) in
       let ts = V4.to_string os in
       assert_equal ~msg:addr ts rt;
     ) addrs
@@ -117,7 +117,7 @@ module Test_v4 = struct
       let os = V4.Prefix.of_string_exn subnet in
       let ts = V4.Prefix.to_string os in
       assert_equal ~msg:subnet ts rt;
-      let os = V4.Prefix.(t_of_sexp (sexp_of_t os)) in
+      let os = Ipaddr_sexp.(V4.Prefix.(t_of_sexp (sexp_of_t os))) in
       let ts = V4.Prefix.to_string os in
       assert_equal ~msg:subnet ts rt;
     ) subnets
@@ -332,7 +332,7 @@ module Test_v6 = struct
       let os = V6.of_string_exn addr in
       let ts = V6.to_string os in
       assert_equal ~msg:(addr^" <> "^rt^" ("^ts^")") ts rt;
-      let os = V6.t_of_sexp (V6.sexp_of_t os) in
+      let os = Ipaddr_sexp.(V6.t_of_sexp (V6.sexp_of_t os)) in
       let ts = V6.to_string os in
       assert_equal ~msg:(addr^" <> "^rt^" ("^ts^")") ts rt;
     ) addrs
@@ -437,7 +437,7 @@ module Test_v6 = struct
       let os = V6.Prefix.of_string_exn subnet in
       let ts = V6.Prefix.to_string os in
       assert_equal ~msg:subnet ts rt;
-      let os = V6.Prefix.(t_of_sexp (sexp_of_t os)) in
+      let os = Ipaddr_sexp.(V6.Prefix.(t_of_sexp (sexp_of_t os))) in
       let ts = V6.Prefix.to_string os in
       assert_equal ~msg:subnet ts rt;
     ) subnets

--- a/lib_test/test_macaddr.ml
+++ b/lib_test/test_macaddr.ml
@@ -32,6 +32,11 @@ let test_string_rt () =
     assert_equal ~msg:(addr ^ " <> " ^ ts) ts addr;
   ) addrs
 
+let assert_result_failure ~msg a =
+  match a with
+  | Ok _ -> assert_failure msg
+  | Error (`Msg _) -> ()
+
 let test_string_rt_bad () =
   let addrs = [
     "ca:fe:ba:be:ee:e";
@@ -41,7 +46,7 @@ let test_string_rt_bad () =
     "ca:fe:ba:be:e:eee";
     "ca:fe:ba:be:ee-ee";
   ] in
-  List.iter (fun addr -> assert_equal ~msg:addr (of_string addr) None) addrs
+  List.iter (fun addr -> assert_result_failure ~msg:addr (of_string addr)) addrs
 
 let test_bytes_rt () =
   let addr = "\254\099\003\128\000\000" in
@@ -53,7 +58,7 @@ let test_bytes_rt_bad () =
     "\254\099\003\128\000\000\233";
   ] in
   List.iter (fun addr ->
-    assert_equal ~msg:(String.escaped addr) (of_bytes addr) None) addrs
+    assert_result_failure ~msg:(String.escaped addr) (of_bytes addr)) addrs
 
 let test_make_local () =
   let () = Random.self_init () in

--- a/lib_test/test_macaddr.ml
+++ b/lib_test/test_macaddr.ml
@@ -27,7 +27,7 @@ let test_string_rt () =
     let os = of_string_exn addr in
     let ts = to_string ~sep os in
     assert_equal ~msg:(addr ^ " <> " ^ ts) ts addr;
-    let os = t_of_sexp (sexp_of_t os) in
+    let os = Macaddr_sexp.(t_of_sexp (sexp_of_t os)) in
     let ts = to_string ~sep os in
     assert_equal ~msg:(addr ^ " <> " ^ ts) ts addr;
   ) addrs

--- a/lib_test/test_ppx.ml
+++ b/lib_test/test_ppx.ml
@@ -1,0 +1,26 @@
+(*
+ * Copyright (c) 2018 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type t = {
+  ip: Ipaddr_sexp.t;
+  ipv6: Ipaddr_sexp.V6.t;
+  ipv6p: Ipaddr_sexp.V6.Prefix.t;
+  ipv4: Ipaddr_sexp.V4.t;
+  ipv4p: Ipaddr_sexp.V4.Prefix.t;
+  scope: Ipaddr_sexp.scope;
+  mac: Macaddr_sexp.t;
+} [@@deriving sexp]

--- a/macaddr.opam
+++ b/macaddr.opam
@@ -10,9 +10,9 @@ bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
-  "base-bytes"
-  "base-unix"
+  "sexplib0"
   "ounit" {with-test}
+  "ppx_sexp_conv" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/macaddr.opam
+++ b/macaddr.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.0"}
   "dune" {build}
   "sexplib0"
   "ounit" {with-test}

--- a/macaddr.opam
+++ b/macaddr.opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "base-bytes"
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"


### PR DESCRIPTION
Just still finishing this of but wanted to preview the PR. This release features several backwards incompatible changes, but ones that should increase the portability and robustness of the library.  Requested by @hannesm for smaller unikernels.

- [x] Remove the sexp serialisers from the main interface in favour of `pp` functions.  Use the `Ipaddr_sexp` module if you still need a sexp serialiser.
- [x] Break out the `Macaddr` module into a separate opam package so that the `Ipaddr` module can be wrapped.
- [x] Replace all the `of_string/bytes` functions that formerly returned option types with the `Rresult` result types instead.
- [x] Remove `pp_hum` which was deprecated in 2.9.0.
- [x] fully update CHANGES
- [x] add Macaddr_sexp
- [x] add ocamldoc to new Sexp modules to explain how they work
- [x] add ppx_deriving_sexp test case (only a test time dependency)