### PR TITLE
Ipaddr.V6.to_string, to_buffer: remove optional labeled argument `v4`

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -550,13 +550,13 @@ module V6 = struct
   let of_string s = try Some (of_string_exn s) with _ -> None
 
   (* http://tools.ietf.org/html/rfc5952 *)
-  let to_buffer ?(v4=false) buf addr =
+  let to_buffer buf addr =
 
     let (a,b,c,d,e,f,g,h) as comp = to_int16 addr in
 
     let v4 = match comp with
       | (0,0,0,0,0,0xffff,_,_) -> true
-      | _ -> v4
+      | _ -> false
     in
 
     let rec loop elide zeros acc = function
@@ -595,9 +595,9 @@ module V6 = struct
       | [] -> ()
     in fill (List.rev lrev)
 
-  let to_string ?v4 l =
+  let to_string l =
     let buf = Buffer.create 39 in
-    to_buffer ?v4 buf l;
+    to_buffer buf l;
     Buffer.contents buf
 
   let pp ppf i =
@@ -759,7 +759,7 @@ module V6 = struct
       ) addr
 
     let to_buffer buf (pre,sz) =
-      Printf.bprintf buf "%a/%d" (to_buffer ~v4:false) pre sz
+      Printf.bprintf buf "%a/%d" to_buffer pre sz
 
     let to_string subnet =
       let buf = Buffer.create 43 in

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -317,11 +317,11 @@ module V6 : sig
 
   (** [to_string ipv6] is the string representation of [ipv6],
       i.e. XXX:XX:X::XXX:XX. *)
-  val to_string : ?v4:bool -> t -> string
+  val to_string : t -> string
 
   (** [to_buffer buf ipv6] writes the string representation of [ipv6] into the
       buffer [buf]. *)
-  val to_buffer : ?v4:bool -> Buffer.t -> t -> unit
+  val to_buffer : Buffer.t -> t -> unit
 
   (** [pp f ipv6] outputs a human-readable representation of [ipv6] to
       the formatter [f]. *)


### PR DESCRIPTION
 was not used, is confusing. the RFC 5952 recommends to output v4-mapped
 addresses as ::ffff:192.168.0.1, which is done nicely by the code.

I searched github, and only https://github.com/mirage/ocaml-tuntap/blob/master/test/getifaddrs_test.ml#L12 uses this, supplying `false`, the default. see https://github.com/mirage/ocaml-tuntap/pull/29 for removing it there :)