### PR TITLE
ipaddr-sexp and macaddr-sexp

### DIFF
--- a/ipaddr-sexp.opam
+++ b/ipaddr-sexp.opam
@@ -1,7 +1,11 @@
 opam-version: "2.0"
 maintainer: "anil@recoil.org"
 authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
-synopsis: "A library for manipulation of MAC address representations"
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Sexp convertions for ipaddr
+"""
+
 license: "ISC"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-ipaddr"
@@ -10,23 +14,13 @@ bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build}
+  "ipaddr"
   "ounit" {with-test}
-  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
 ]
-conflicts: [ "ipaddr" {< "3.0.0"} ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
-description: """
-A library for manipulation of MAC address representations.
-
-Features:
-
- * oUnit-based tests
- * MAC-48 (Ethernet) address support
- * `Macaddr` is a `Map.OrderedType`
- * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
- """

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -30,9 +30,8 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build}
   "macaddr"
-  "sexplib0"
   "ounit" {with-test}
-  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/lib/dune
+++ b/lib/dune
@@ -11,14 +11,16 @@
 
 (library
  (name        ipaddr_sexp)
- (public_name ipaddr.sexp)
+ (public_name ipaddr-sexp)
  (modules ipaddr_sexp)
+ (preprocess (pps ppx_sexp_conv))
  (libraries ipaddr sexplib0))
 
 (library
  (name        macaddr_sexp)
- (public_name macaddr.sexp)
+ (public_name macaddr-sexp)
  (modules macaddr_sexp)
+ (preprocess (pps ppx_sexp_conv))
  (libraries macaddr sexplib0))
 
 (library

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,19 +1,34 @@
-(executables
- (names test_ipaddr test_macaddr test_ppx)
+(rule (copy# ../lib/ipaddr_sexp.ml ipaddr_sexp.ml))
+(rule (copy# ../lib/macaddr_sexp.ml macaddr_sexp.ml))
+
+(library
+ (name test_macaddr_sexp)
+ (wrapped false)
+ (modules macaddr_sexp)
  (preprocess (pps ppx_sexp_conv))
- (libraries ipaddr oUnit ipaddr.sexp macaddr.sexp))
+ (libraries macaddr sexplib0))
 
-(alias
- (name    runtest)
- (deps    test_ppx.exe)
- (action  (run %{deps})))
+(library
+ (name test_ipaddr_sexp)
+ (wrapped false)
+ (modules ipaddr_sexp)
+ (preprocess (pps ppx_sexp_conv))
+ (libraries ipaddr sexplib0))
 
-(alias
- (name    runtest)
- (deps    test_macaddr.exe)
- (action  (run %{deps})))
+(test
+ (name test_ipaddr)
+ (package ipaddr)
+ (modules test_ipaddr)
+ (libraries ipaddr test_ipaddr_sexp oUnit))
 
-(alias
- (name    runtest)
- (deps    test_ipaddr.exe)
- (action  (run %{deps})))
+(test
+ (name test_macaddr)
+ (package macaddr)
+ (modules test_macaddr)
+ (libraries macaddr test_macaddr_sexp oUnit))
+
+(test
+ (name test_ppx)
+ (modules test_ppx)
+ (package ipaddr)
+ (libraries ipaddr macaddr test_ipaddr_sexp test_macaddr_sexp oUnit))

--- a/macaddr-sexp.opam
+++ b/macaddr-sexp.opam
@@ -10,8 +10,9 @@ bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build}
+  "macaddr"
   "ounit" {with-test}
-  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
 ]
 conflicts: [ "ipaddr" {< "3.0.0"} ]
 build: [
@@ -21,12 +22,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
 description: """
-A library for manipulation of MAC address representations.
-
-Features:
-
- * oUnit-based tests
- * MAC-48 (Ethernet) address support
- * `Macaddr` is a `Map.OrderedType`
- * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
- """
+Sexp convertions for macaddr
+"""


### PR DESCRIPTION
Moves `Ipaddr_sexp` and `Macaddr_sexp` to their own opam packages.

I had to use the same hack as https://github.com/mirage/ocaml-uri/pull/134 to make `dune-release` happy. Is there a cleaner way ?