### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/ipaddr-cstruct.opam
+++ b/ipaddr-cstruct.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "ipaddr" {=version}
   "cstruct"
 ]

--- a/ipaddr-sexp.opam
+++ b/ipaddr-sexp.opam
@@ -13,7 +13,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "ipaddr"
   "ipaddr-cstruct" {with-test}
   "ounit" {with-test}

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -28,7 +28,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "macaddr" {=version}
   "sexplib0"
   "domain-name" {>= "0.3.0"}

--- a/macaddr-cstruct.opam
+++ b/macaddr-cstruct.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "macaddr" {=version}
   "cstruct"
 ]

--- a/macaddr-sexp.opam
+++ b/macaddr-sexp.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "macaddr"
   "macaddr-cstruct" {with-test}
   "ounit" {with-test}

--- a/macaddr.opam
+++ b/macaddr.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "ounit" {with-test}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.