### PR TITLE
Utility functions

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -496,7 +496,7 @@ module B128 = struct
     in
     match List.fold_left cb (1l,[]) [d;c;b;a] with
     | 0l, [a;b;c;d] -> of_int32 (a,b,c,d)
-    | n, [_;_;_;_] when n > 0l -> failwith "B128 overflow"
+    | n, [a;b;c;d] when n > 0l -> of_int32 (a,b,c,d)
     | _ -> failwith "Unexpected error with B128"
 
   let pred (a,b,c,d) =
@@ -514,7 +514,7 @@ module B128 = struct
     in
     match List.fold_left cb (-1l,[]) [d;c;b;a] with
     | 0l, [a;b;c;d] -> of_int32 (a,b,c,d)
-    | n, [_;_;_;_] when n < 0l -> failwith "B128 overflow"
+    | n, [a;b;c;d] when n < 0l -> of_int32 (a,b,c,d)
     | _ -> failwith "Unexpected error with B128"
 
   let shift_right (a,b,c,d) sz =

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -148,6 +148,14 @@ module V4 : sig
       suffix, and an IPv4 address prefixed. *)
   val of_domain_name : 'a Domain_name.t -> t option
 
+  (** {3 Utility functions} *)
+
+  (** [succ ipv4] is ip address next to [ipv4] *)
+  val succ : t -> t
+
+  (** [pred ipv4] is ip address before [ipv4] *)
+  val pred : t -> t
+
   (** {3 Common addresses} *)
 
   (** [any] is 0.0.0.0. *)
@@ -290,6 +298,12 @@ module V4 : sig
     (** [bits subnet] is the bit size of the [subnet] prefix. *)
     val bits : t -> int
 
+    (** [first subnet] is first valid unicast address in this [subnet]. *)
+    val first : t -> addr
+
+    (** [last subnet] is last valid unicast address in this [subnet]. *)
+    val last : t -> addr
+
     include Map.OrderedType with type t := t
   end
 
@@ -411,6 +425,14 @@ module V6 : sig
   (** [of_domain_name name] is [Some t] if the [name] has an [.ip6.arpa]
       suffix, and an IPv6 address prefixed. *)
   val of_domain_name : 'a Domain_name.t -> t option
+
+  (** {3 Utility functions} *)
+
+  (** [succ ipv6] is ip address next to [ipv6] *)
+  val succ : t -> t
+
+  (** [pred ipv6] is ip address before [ipv6] *)
+  val pred : t -> t
 
   (** {3 Common addresses} *)
 
@@ -546,6 +568,12 @@ module V6 : sig
     (** [bits subnet] is the bit size of the [subnet] prefix. *)
     val bits : t -> int
 
+    (** [first subnet] is first valid unicast address in this [subnet]. *)
+    val first : t -> addr
+
+    (** [last subnet] is last valid unicast address in this [subnet]. *)
+    val last : t -> addr
+
     include Map.OrderedType with type t := t
   end
 
@@ -647,6 +675,12 @@ val to_domain_name : t -> [ `host ] Domain_name.t
     [ip6.arpa] suffix, and an IP address prefixed. *)
 val of_domain_name : 'a Domain_name.t -> t option
 
+(** [succ addr] is ip address next to [addr] *)
+val succ : t -> t
+
+(** [pred addr] is ip address before [addr] *)
+val pred : t -> t
+
 module Prefix : sig
   type addr = t
 
@@ -705,6 +739,12 @@ module Prefix : sig
 
   (** [netmask subnet] is the netmask for [subnet]. *)
   val netmask : t -> addr
+
+  (** [first subnet] is first valid unicast address in this [subnet]. *)
+  val first : t -> addr
+
+  (** [last subnet] is last valid unicast address in this [subnet]. *)
+  val last : t -> addr
 
   include Map.OrderedType with type t := t
 end

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -150,11 +150,13 @@ module V4 : sig
 
   (** {3 Utility functions} *)
 
-  (** [succ ipv4] is ip address next to [ipv4] *)
-  val succ : t -> t
+  (** [succ ipv4] is ip address next to [ipv4].
+      Returns a human-readable error string if it's already the highest address. *)
+  val succ : t -> (t, [> `Msg of string ]) result
 
-  (** [pred ipv4] is ip address before [ipv4] *)
-  val pred : t -> t
+  (** [pred ipv4] is ip address before [ipv4].
+      Returns a human-readable error string if it's already the lowest address. *)
+  val pred : t -> (t, [> `Msg of string ]) result
 
   (** {3 Common addresses} *)
 
@@ -428,11 +430,13 @@ module V6 : sig
 
   (** {3 Utility functions} *)
 
-  (** [succ ipv6] is ip address next to [ipv6] *)
-  val succ : t -> t
+  (** [succ ipv6] is ip address next to [ipv6]. Returns a human-readable
+      error string if it's already the highest address. *)
+  val succ : t -> (t, [> `Msg of string ]) result
 
-  (** [pred ipv6] is ip address before [ipv6] *)
-  val pred : t -> t
+  (** [pred ipv6] is ip address before [ipv6]. Returns a human-readable
+      error string if it's already the lowest address. *)
+  val pred : t -> (t, [> `Msg of string ]) result
 
   (** {3 Common addresses} *)
 
@@ -675,11 +679,13 @@ val to_domain_name : t -> [ `host ] Domain_name.t
     [ip6.arpa] suffix, and an IP address prefixed. *)
 val of_domain_name : 'a Domain_name.t -> t option
 
-(** [succ addr] is ip address next to [addr] *)
-val succ : t -> t
+(** [succ addr] is ip address next to [addr]. Returns a human-readable
+    error string if it's already the highest address. *)
+val succ : t -> (t, [> `Msg of string ]) result
 
-(** [pred addr] is ip address before [addr] *)
-val pred : t -> t
+(** [pred addr] is ip address before [addr]. Returns a human-readable
+    error string if it's already the lowest address. *)
+val pred : t -> (t, [> `Msg of string ]) result
 
 module Prefix : sig
   type addr = t

--- a/lib/ipaddr_sexp.ml
+++ b/lib/ipaddr_sexp.ml
@@ -91,3 +91,17 @@ type scope = I.scope
 let sexp_of_scope = to_sexp I.string_of_scope
 
 let scope_of_sexp = of_sexp I.scope_of_string
+
+module Prefix = struct
+  module I = Ipaddr.Prefix
+
+  type addr = I.addr
+
+  type t = I.t
+
+  let sexp_of_t = to_sexp I.to_string
+
+  let t_of_sexp = of_sexp I.of_string
+
+  let compare = I.compare
+end

--- a/lib/ipaddr_sexp.mli
+++ b/lib/ipaddr_sexp.mli
@@ -99,3 +99,15 @@ module V6 : sig
     val compare : Ipaddr.V6.Prefix.t -> Ipaddr.V6.Prefix.t -> int
   end
 end
+
+module Prefix : sig
+  type addr = Ipaddr.Prefix.addr
+
+  type t = Ipaddr.Prefix.t
+
+  val sexp_of_t : Ipaddr.Prefix.t -> Sexplib0.Sexp.t
+
+  val t_of_sexp : Sexplib0.Sexp.t -> Ipaddr.Prefix.t
+
+  val compare : Ipaddr.Prefix.t -> Ipaddr.Prefix.t -> int
+end

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,7 @@
 (rule (copy# ../lib/ipaddr_sexp.ml ipaddr_sexp.ml))
 (rule (copy# ../lib/macaddr_sexp.ml macaddr_sexp.ml))
+(rule (copy# ../lib/ipaddr.ml ipaddr_internal.ml))
+
 
 (library
  (name test_macaddr_sexp)
@@ -19,6 +21,12 @@
  (name test_ipaddr)
  (package ipaddr-sexp)
  (modules test_ipaddr)
+ (libraries ipaddr ipaddr-cstruct test_ipaddr_sexp oUnit))
+
+(test
+ (name test_ipaddr_b128)
+ (package ipaddr-sexp)
+ (modules test_ipaddr_b128 ipaddr_internal)
  (libraries ipaddr ipaddr-cstruct test_ipaddr_sexp oUnit))
 
 (test

--- a/lib_test/test_ipaddr_b128.ml
+++ b/lib_test/test_ipaddr_b128.ml
@@ -1,0 +1,55 @@
+(*
+ * Copyright (c) 2013-2014 David Sheets <sheets@alum.mit.edu>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open OUnit
+
+let test_shift_right () =
+  let open Ipaddr_internal in
+  let open V6 in
+  let assert_equal = assert_equal ~printer:to_string in
+  assert_equal ~msg:":: >> 32"
+    (of_string_exn "::")
+    (B128.shift_right (of_string_exn "::ffff:ffff") 32);
+  assert_equal ~msg:"::aaaa:bbbb:ffff:ffff >> 32"
+    (of_string_exn "::aaaa:bbbb")
+    (B128.shift_right (of_string_exn "::aaaa:bbbb:ffff:ffff") 32);
+  assert_equal ~msg:"::aaaa:bbbb:ffff:ffff >> 40"
+    (of_string_exn "::aa:aabb")
+    (B128.shift_right (of_string_exn "::aaaa:bbbb:ffff:ffff")  40);
+  assert_equal ~msg:"::ffff >> 2"
+    (of_string_exn "::3fff")
+    (B128.shift_right (of_string_exn "::ffff")  2);
+  assert_equal ~msg:"ffff:: >> 128"
+    (of_string_exn "::")
+    (B128.shift_right (of_string_exn "ffff::")  128);
+  assert_equal ~msg:"aaaa:bbbb:cccc:dddd:: >> 120"
+    (of_string_exn "::aa")
+    (B128.shift_right (of_string_exn "aaaa:bbbb:cccc:dddd::")  120);
+  assert_equal ~msg:"ffff:: >> 140"
+    (of_string_exn "::")
+    (B128.shift_right (of_string_exn "ffff::")  140);
+  assert_equal ~msg:"::ffff:ffff >> -8"
+    (of_string_exn "::")
+    (B128.shift_right (of_string_exn "::ffff:ffff") (-8))
+
+let suite = "Test B128 module" >::: [
+  "shift_right"       >:: test_shift_right;
+]
+
+;;
+let _results = run_test_tt_main suite in
+()

--- a/lib_test/test_ipaddr_b128.ml
+++ b/lib_test/test_ipaddr_b128.ml
@@ -20,30 +20,34 @@ open OUnit
 let test_shift_right () =
   let open Ipaddr_internal in
   let open V6 in
-  let assert_equal = assert_equal ~printer:to_string in
+  let printer = function
+    | Ok v -> Printf.sprintf "Ok %s" (to_string v)
+    | Error (`Msg e) -> Printf.sprintf "Error `Msg \"%s\"" e
+  in
+  let assert_equal = assert_equal ~printer in
   assert_equal ~msg:":: >> 32"
-    (of_string_exn "::")
+    (of_string "::")
     (B128.shift_right (of_string_exn "::ffff:ffff") 32);
   assert_equal ~msg:"::aaaa:bbbb:ffff:ffff >> 32"
-    (of_string_exn "::aaaa:bbbb")
+    (of_string "::aaaa:bbbb")
     (B128.shift_right (of_string_exn "::aaaa:bbbb:ffff:ffff") 32);
   assert_equal ~msg:"::aaaa:bbbb:ffff:ffff >> 40"
-    (of_string_exn "::aa:aabb")
+    (of_string "::aa:aabb")
     (B128.shift_right (of_string_exn "::aaaa:bbbb:ffff:ffff")  40);
   assert_equal ~msg:"::ffff >> 2"
-    (of_string_exn "::3fff")
+    (of_string "::3fff")
     (B128.shift_right (of_string_exn "::ffff")  2);
   assert_equal ~msg:"ffff:: >> 128"
-    (of_string_exn "::")
+    (of_string "::")
     (B128.shift_right (of_string_exn "ffff::")  128);
   assert_equal ~msg:"aaaa:bbbb:cccc:dddd:: >> 120"
-    (of_string_exn "::aa")
+    (of_string "::aa")
     (B128.shift_right (of_string_exn "aaaa:bbbb:cccc:dddd::")  120);
   assert_equal ~msg:"ffff:: >> 140"
-    (of_string_exn "::")
+    (of_string "::")
     (B128.shift_right (of_string_exn "ffff::")  140);
   assert_equal ~msg:"::ffff:ffff >> -8"
-    (of_string_exn "::")
+    (of_string "::")
     (B128.shift_right (of_string_exn "::ffff:ffff") (-8))
 
 let suite = "Test B128 module" >::: [

--- a/lib_test/test_ppx.ml
+++ b/lib_test/test_ppx.ml
@@ -23,4 +23,5 @@ type t = {
   ipv4p: Ipaddr_sexp.V4.Prefix.t;
   scope: Ipaddr_sexp.scope;
   mac: Macaddr_sexp.t;
+  ipp: Ipaddr_sexp.Prefix.t;
 } [@@deriving sexp]


### PR DESCRIPTION
Hi there! I think these improvements would be useful not only for me.
- added forgotten `Ipaddr_sexp.Prefix` module
- for `Ipaddr`, `Ipaddr.V4` and `Ipaddr.V6` added functions `succ` and `pred` to get next and previous addresses
- for `Ipaddr.Prefix`, `Ipaddr.V4.Prefix` and `Ipaddr.V6.Prefix` added functions `first` and `last` to get first and last valid unicast addresses in subnet
