### PR TITLE
Prefix.of_netmask: avoid exceptions, provide of_netmask_exn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
-## v4.0.1
+## v5.0.0
 
 * Use stdlib-shims to prevent deprecation warnings on OCaml 4.08
   (@avsm)
+* Rename `Prefix.of_netmask` to `Prefix.of_netmask_exn` with labelled
+  arguments (~netmask and ~address), provide `Prefix.of_netmask` which returns
+  a (t, [> `Msg of string ]) result value (#95 @hannesm)
 
 ## v4.0.0 (2019-07-12)
 

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -30,7 +30,6 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune"
   "macaddr" {=version}
-  "sexplib0"
   "stdlib-shims"
   "domain-name" {>= "0.3.0"}
   "ounit" {with-test}

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -230,9 +230,14 @@ module V4 : sig
         network address representing [addr] in [prefix] to the buffer [buf]. *)
     val to_address_buffer : Buffer.t -> t -> addr -> unit
 
-    (** [of_netmask netmask addr] is the subnet prefix of [addr] with netmask
-        [netmask]. *)
-    val of_netmask : addr -> addr -> t
+    (** [of_netmask_exn ~netmask ~address] is the subnet prefix of [address]
+        with netmask [netmask]. *)
+    val of_netmask_exn : netmask:addr -> address:addr -> t
+
+    (** [of_netmask ~netmask ~address] is the subnet prefix of [address] with
+        netmask [netmask]. *)
+    val of_netmask : netmask:addr -> address:addr ->
+      (t, [> `Msg of string ]) result
 
     (** [mem ip subnet] checks whether [ip] is found within [subnet]. *)
     val mem : addr -> t -> bool
@@ -490,9 +495,14 @@ module V6 : sig
         network address representing [addr] in [prefix] to the buffer [buf]. *)
     val to_address_buffer : Buffer.t -> t -> addr -> unit
 
-    (** [of_netmask netmask addr] is the subnet prefix of [addr] with netmask
-        [netmask]. *)
-    val of_netmask : addr -> addr -> t
+    (** [of_netmask_exn ~netmask ~address] is the subnet prefix of [address]
+        with netmask [netmask]. *)
+    val of_netmask_exn : netmask:addr -> address:addr -> t
+
+    (** [of_netmask ~netmask ~address] is the subnet prefix of [address] with
+        netmask [netmask]. *)
+    val of_netmask : netmask:addr -> address:addr ->
+      (t, [> `Msg of string ]) result
 
     (** [mem ip subnet] checks whether [ip] is found within [subnet]. *)
     val mem : addr -> t -> bool

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -183,13 +183,13 @@ module Test_v4 = struct
       "192.168.0.1/0", "0.0.0.0";
     ] in
     List.iter (fun (net_str,nm_str) ->
-      let prefix, v4 = V4.Prefix.of_address_string_exn net_str in
-      let nm = V4.Prefix.netmask prefix in
-      let nnm_str = V4.to_string nm in
+      let prefix, address = V4.Prefix.of_address_string_exn net_str in
+      let netmask = V4.Prefix.netmask prefix in
+      let nnm_str = V4.to_string netmask in
       let msg = Printf.sprintf "netmask %s <> %s" nnm_str nm_str in
       assert_equal ~msg nnm_str nm_str;
-      let prefix = V4.Prefix.of_netmask nm v4 in
-      let nns = V4.Prefix.to_address_string prefix v4 in
+      let prefix = V4.Prefix.of_netmask_exn ~netmask ~address in
+      let nns = V4.Prefix.to_address_string prefix address in
       let msg = Printf.sprintf "%s is %s under netmask iso" net_str nns in
       assert_equal ~msg net_str nns
     ) nets
@@ -200,9 +200,10 @@ module Test_v4 = struct
       error "255.255.254.128" "invalid netmask";
     ] in
     List.iter (fun (nm_str,exn) ->
-      let nm = V4.of_string_exn nm_str in
-      let addr = V4.of_string_exn "192.168.0.1" in
-      assert_raises ~msg:nm_str exn (fun () -> V4.Prefix.of_netmask nm addr)
+      let netmask = V4.of_string_exn nm_str in
+      let address = V4.of_string_exn "192.168.0.1" in
+      assert_raises ~msg:nm_str exn
+        (fun () -> V4.Prefix.of_netmask_exn ~netmask ~address)
     ) bad_masks
 
   let test_scope () =
@@ -527,13 +528,13 @@ module Test_v6 = struct
       "8::1/0",  "::";
     ] in
     List.iter (fun (net_str,nm_str) ->
-      let prefix, v6 = V6.Prefix.of_address_string_exn net_str in
-      let nm = V6.Prefix.netmask prefix in
-      let nnm_str = V6.to_string nm in
+      let prefix, address = V6.Prefix.of_address_string_exn net_str in
+      let netmask = V6.Prefix.netmask prefix in
+      let nnm_str = V6.to_string netmask in
       let msg = Printf.sprintf "netmask %s <> %s" nnm_str nm_str in
       assert_equal ~msg nnm_str nm_str;
-      let prefix = V6.Prefix.of_netmask nm v6 in
-      let nns = V6.Prefix.to_address_string prefix v6 in
+      let prefix = V6.Prefix.of_netmask_exn ~netmask ~address in
+      let nns = V6.Prefix.to_address_string prefix address in
       let msg = Printf.sprintf "%s is %s under netmask iso" net_str nns in
       assert_equal ~msg net_str nns
     ) nets
@@ -546,9 +547,10 @@ module Test_v6 = struct
       error "ffff:fffe:8000::" "invalid netmask";
     ] in
     List.iter (fun (nm_str,exn) ->
-      let nm = V6.of_string_exn nm_str in
-      let addr = V6.of_string_exn "::" in
-      assert_raises ~msg:nm_str exn (fun () -> V6.Prefix.of_netmask nm addr)
+      let netmask = V6.of_string_exn nm_str in
+      let address = V6.of_string_exn "::" in
+      assert_raises ~msg:nm_str exn
+        (fun () -> V6.Prefix.of_netmask_exn ~netmask ~address)
     ) bad_masks
 
   let test_scope () =


### PR DESCRIPTION
while trying to use ipaddr 4.0.0, I discovered that the Prefix.of_netmask functions are in a slightly sad state:
- they raise exceptions
- they get two arguments of type addr -- and I always get the order wrong

so I instead:
- changed the signature of of_netmask : netmask:addr -> address:addr -> (t, msg) result
- provided a of_netmask_exn, which value is t

~~in a separate commit I use stdlib-shims to have this compile without warnings on newer OCaml compilers~~. also, remove the `sexplib0` dependency from ipaddr.opam. I know this breaks the API again, but only for some users ;) -- and better to have it coherent now than to embed the boilerplate to get a result from of_netmask in all the clients.