### PR TITLE
reject octal notation in ivp4

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -82,6 +82,10 @@ let bad_char i s =
   let msg = Printf.sprintf "invalid character '%c' at %d" s.[i] i in
   Parse_error (msg, s)
 
+let octal_notation s =
+  let msg = Printf.sprintf "octal notation disallowed" in
+  Parse_error (msg, s)
+
 let is_number base n = n >= 0 && n < base
 
 let parse_int base s i =
@@ -112,6 +116,10 @@ let expect_char s i c =
   else raise (need_more s)
 
 let expect_end s i = if String.length s <= !i then () else raise (bad_char !i s)
+
+let reject_octal s i =
+  if !i + 1 < String.length s then
+    if s.[!i] == '0' && is_number 10 (int_of_char s.[!i + 1]) then raise (octal_notation s)
 
 let hex_char_of_int = function
   | 0 -> '0'
@@ -147,12 +155,16 @@ module V4 = struct
   (* parsing *)
 
   let parse_dotted_quad s i =
+    reject_octal s i;
     let a = parse_dec_int s i in
     expect_char s i '.';
+    reject_octal s i;
     let b = parse_dec_int s i in
     expect_char s i '.';
+    reject_octal s i;
     let c = parse_dec_int s i in
     expect_char s i '.';
+    reject_octal s i;
     let d = parse_dec_int s i in
     let valid a = a land 0xff <> a in
     if valid a then raise (Parse_error ("first octet out of bounds", s))

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -423,6 +423,39 @@ module Test_v4 = struct
       (Ipaddr.V4.of_string_exn "169.254.169.254")
       (last (of_string_exn "169.254.169.254/32"))
 
+
+  let test_reject_octal () =
+    let bad_addrs =
+      [
+        error "010.8.8.8" "octal notation disallowed";
+        error "8.010.8.8" "octal notation disallowed";
+        error "8.8.010.8" "octal notation disallowed";
+        error "8.8.8.010" "octal notation disallowed";
+      ]
+    in
+    List.iter
+      (fun (addr, exn) ->
+         assert_raises ~msg:addr exn (fun () ->
+           V4.of_string_exn addr))
+      bad_addrs
+
+
+  let test_reject_prefix_octal () =
+    let bad_addrs =
+      [
+        error "010.8.8.8/32" "octal notation disallowed";
+        error "8.010.8.8/32" "octal notation disallowed";
+        error "8.8.010.8/32" "octal notation disallowed";
+        error "8.8.8.010/32" "octal notation disallowed";
+      ]
+    in
+    List.iter
+      (fun (addr, exn) ->
+         assert_raises ~msg:addr exn (fun () ->
+           V4.Prefix.of_string_exn addr))
+      bad_addrs
+
+
   let suite =
     "Test V4"
     >::: [
@@ -451,6 +484,8 @@ module Test_v4 = struct
            "prefix_mem" >:: test_prefix_mem;
            "succ_pred" >:: test_succ_pred;
            "prefix_first_last" >:: test_prefix_first_last;
+           "reject_octal" >:: test_reject_octal;
+           "reject_prefix_octal" >:: test_reject_prefix_octal;
          ]
 end
 


### PR DESCRIPTION
Based on a recent CVE, I propose a patch to reject the use of octal notation in IPv4.

See some related information here:
https://www.bleepingcomputer.com/news/security/python-also-impacted-by-critical-ip-address-validation-vulnerability/