### PR TITLE
Fixes: cstruct 6.0.0 and Set and Map

### DIFF
--- a/ipaddr-cstruct.opam
+++ b/ipaddr-cstruct.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.9.0"}
   "ipaddr" {= version}
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -451,6 +451,16 @@ module V4 = struct
   let is_multicast i = Prefix.(mem i multicast)
 
   let is_private i = scope i <> Global
+
+  module Set = Set.Make(struct
+      type nonrec t = t
+      let compare (a : t) (b : t) = compare a b
+    end)
+
+  module Map = Map.Make(struct
+      type nonrec t = t
+      let compare (a : t) (b : t) = compare a b
+    end)
 end
 
 module B128 = struct
@@ -992,6 +1002,16 @@ module V6 = struct
   let is_multicast i = Prefix.(mem i multicast)
 
   let is_private i = scope i <> Global
+
+  module Set = Set.Make(struct
+      type nonrec t = t
+      let compare (a : t) (b : t) = compare a b
+    end)
+
+  module Map = Map.Make(struct
+      type nonrec t = t
+      let compare (a : t) (b : t) = compare a b
+    end)
 end
 
 type ('v4, 'v6) v4v6 = V4 of 'v4 | V6 of 'v6
@@ -1004,6 +1024,16 @@ let compare a b =
   | V6 a, V6 b -> V6.compare a b
   | V4 _, V6 _ -> -1
   | V6 _, V4 _ -> 1
+
+module Set = Set.Make(struct
+    type nonrec t = t
+    let compare (a : t) (b : t) = compare a b
+  end)
+
+module Map = Map.Make(struct
+    type nonrec t = t
+    let compare (a : t) (b : t) = compare a b
+  end)
 
 let to_string = function V4 x -> V4.to_string x | V6 x -> V6.to_string x
 

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -452,15 +452,17 @@ module V4 = struct
 
   let is_private i = scope i <> Global
 
-  module Set = Set.Make(struct
-      type nonrec t = t
-      let compare (a : t) (b : t) = compare a b
-    end)
+  module Set = Set.Make (struct
+    type nonrec t = t
 
-  module Map = Map.Make(struct
-      type nonrec t = t
-      let compare (a : t) (b : t) = compare a b
-    end)
+    let compare (a : t) (b : t) = compare a b
+  end)
+
+  module Map = Map.Make (struct
+    type nonrec t = t
+
+    let compare (a : t) (b : t) = compare a b
+  end)
 end
 
 module B128 = struct
@@ -1003,15 +1005,17 @@ module V6 = struct
 
   let is_private i = scope i <> Global
 
-  module Set = Set.Make(struct
-      type nonrec t = t
-      let compare (a : t) (b : t) = compare a b
-    end)
+  module Set = Set.Make (struct
+    type nonrec t = t
 
-  module Map = Map.Make(struct
-      type nonrec t = t
-      let compare (a : t) (b : t) = compare a b
-    end)
+    let compare (a : t) (b : t) = compare a b
+  end)
+
+  module Map = Map.Make (struct
+    type nonrec t = t
+
+    let compare (a : t) (b : t) = compare a b
+  end)
 end
 
 type ('v4, 'v6) v4v6 = V4 of 'v4 | V6 of 'v6
@@ -1025,15 +1029,17 @@ let compare a b =
   | V4 _, V6 _ -> -1
   | V6 _, V4 _ -> 1
 
-module Set = Set.Make(struct
-    type nonrec t = t
-    let compare (a : t) (b : t) = compare a b
-  end)
+module Set = Set.Make (struct
+  type nonrec t = t
 
-module Map = Map.Make(struct
-    type nonrec t = t
-    let compare (a : t) (b : t) = compare a b
-  end)
+  let compare (a : t) (b : t) = compare a b
+end)
+
+module Map = Map.Make (struct
+  type nonrec t = t
+
+  let compare (a : t) (b : t) = compare a b
+end)
 
 let to_string = function V4 x -> V4.to_string x | V6 x -> V6.to_string x
 

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -309,6 +309,10 @@ module V4 : sig
       addresses a node. *)
 
   include Map.OrderedType with type t := t
+
+  module Set : Set.S with type elt := t
+
+  module Map : Map.S with type key := t
 end
 
 (** A collection of functions for IPv6 addresses. *)
@@ -576,6 +580,10 @@ module V6 : sig
       addresses a node. *)
 
   include Map.OrderedType with type t := t
+
+  module Set : Set.S with type elt := t
+
+  module Map : Map.S with type key := t
 end
 
 (** Type of either an IPv4 value or an IPv6 value *)
@@ -726,3 +734,7 @@ module Prefix : sig
 end
 
 include Map.OrderedType with type t := t
+
+module Set : Set.S with type elt := t
+
+module Map : Map.S with type key := t

--- a/lib/ipaddr_cstruct.ml
+++ b/lib/ipaddr_cstruct.ml
@@ -24,14 +24,14 @@ let try_with_result fn a =
 
 module V4 = struct
   let of_cstruct_exn cs =
-    let len = Cstruct.len cs in
+    let len = Cstruct.length cs in
     if len < 4 then raise (need_more (Cstruct.to_string cs));
     Ipaddr.V4.of_int32 (Cstruct.BE.get_uint32 cs 0)
 
   let of_cstruct cs = try_with_result of_cstruct_exn cs
 
   let write_cstruct_exn i cs =
-    let len = Cstruct.len cs in
+    let len = Cstruct.length cs in
     if len < 4 then raise (need_more (Cstruct.to_string cs));
     Cstruct.BE.set_uint32 cs 0 (Ipaddr.V4.to_int32 i)
 
@@ -45,7 +45,7 @@ module V6 = struct
   open Ipaddr.V6
 
   let of_cstruct_exn cs =
-    let len = Cstruct.len cs in
+    let len = Cstruct.length cs in
     if len < 16 then raise (need_more (Cstruct.to_string cs));
     let hihi = Cstruct.BE.get_uint32 cs 0 in
     let hilo = Cstruct.BE.get_uint32 cs 4 in
@@ -56,7 +56,7 @@ module V6 = struct
   let of_cstruct cs = try_with_result of_cstruct_exn cs
 
   let write_cstruct_exn i cs =
-    let len = Cstruct.len cs in
+    let len = Cstruct.length cs in
     if len < 16 then raise (need_more (Cstruct.to_string cs));
     let a, b, c, d = to_int32 i in
     Cstruct.BE.set_uint32 cs 0 a;

--- a/lib/macaddr_cstruct.ml
+++ b/lib/macaddr_cstruct.ml
@@ -21,14 +21,14 @@ let try_with_result fn a =
   with Macaddr.Parse_error (msg, _) -> Error (`Msg ("Macaddr: " ^ msg))
 
 let of_cstruct_exn cs =
-  if Cstruct.len cs <> 6 then
+  if Cstruct.length cs <> 6 then
     raise (Macaddr.Parse_error ("MAC is exactly 6 bytes", Cstruct.to_string cs))
   else Cstruct.to_string cs |> Macaddr.of_octets_exn
 
 let of_cstruct cs = try_with_result of_cstruct_exn cs
 
 let write_cstruct_exn (mac : Macaddr.t) cs =
-  let len = Cstruct.len cs in
+  let len = Cstruct.length cs in
   let mac = Macaddr.to_octets mac in
   if len <> 6 then raise (Macaddr.Parse_error ("MAC is exactly 6 bytes", mac));
   Cstruct.blit_from_string mac 0 cs 0 6

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -282,21 +282,22 @@ module Test_v4 = struct
       ships
 
   let test_map () =
-    let module M = Map.Make (V4) in
-    let m = M.add (V4.of_string_exn "1.0.0.1") "min" M.empty in
-    let m = M.add (V4.of_string_exn "254.254.254.254") "the greatest host" m in
-    let m = M.add (V4.of_string_exn "1.0.0.1") "the least host" m in
-    assert_equal ~msg:"size" (M.cardinal m) 2;
-    let min_key, min_val = M.min_binding m in
+    let m = V4.Map.add (V4.of_string_exn "1.0.0.1") "min" V4.Map.empty in
+    let m =
+      V4.Map.add (V4.of_string_exn "254.254.254.254") "the greatest host" m
+    in
+    let m = V4.Map.add (V4.of_string_exn "1.0.0.1") "the least host" m in
+    assert_equal ~msg:"size" (V4.Map.cardinal m) 2;
+    let min_key, min_val = V4.Map.min_binding m in
     assert_equal
       ~msg:("min is '" ^ min_val ^ "'")
       (min_key, min_val)
       (V4.of_string_exn "1.0.0.1", "the least host");
-    assert_equal ~msg:"max" (M.max_binding m)
+    assert_equal ~msg:"max" (V4.Map.max_binding m)
       (V4.of_string_exn "254.254.254.254", "the greatest host")
 
   let test_prefix_map () =
-    let module M = Map.Make (V4.Prefix) in
+    let module M = Stdlib.Map.Make (V4.Prefix) in
     let of_string s = s |> V4.Prefix.of_string_exn |> V4.Prefix.prefix in
     let m = M.add (of_string "0.0.0.0/0") "everyone" M.empty in
     let m = M.add (of_string "192.0.0.0/1") "weirdos" m in
@@ -791,22 +792,21 @@ module Test_v6 = struct
       ships
 
   let test_map () =
-    let module M = Map.Make (V6) in
     let maxs = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" in
-    let m = M.add (V6.of_string_exn "::0:0") "min" M.empty in
-    let m = M.add (V6.of_string_exn maxs) "the greatest host" m in
-    let m = M.add (V6.of_string_exn "::") "the least host" m in
-    assert_equal ~msg:"size" (M.cardinal m) 2;
-    let min_key, min_val = M.min_binding m in
+    let m = V6.Map.add (V6.of_string_exn "::0:0") "min" V6.Map.empty in
+    let m = V6.Map.add (V6.of_string_exn maxs) "the greatest host" m in
+    let m = V6.Map.add (V6.of_string_exn "::") "the least host" m in
+    assert_equal ~msg:"size" (V6.Map.cardinal m) 2;
+    let min_key, min_val = V6.Map.min_binding m in
     assert_equal
       ~msg:("min is '" ^ min_val ^ "'")
       (min_key, min_val)
       (V6.of_string_exn "::0:0:0", "the least host");
-    assert_equal ~msg:"max" (M.max_binding m)
+    assert_equal ~msg:"max" (V6.Map.max_binding m)
       (V6.of_string_exn maxs, "the greatest host")
 
   let test_prefix_map () =
-    let module M = Map.Make (V6.Prefix) in
+    let module M = Stdlib.Map.Make (V6.Prefix) in
     let of_string s = s |> V6.Prefix.of_string_exn |> V6.Prefix.prefix in
     let m = M.add (of_string "::ffff:0.0.0.0/0") "everyone" M.empty in
     let m = M.add (of_string "::ffff:192.0.0.0/1") "weirdos" m in
@@ -981,22 +981,21 @@ let test_string_raw_rt_bad () =
     addrs
 
 let test_map () =
-  let module M = Map.Make (Ipaddr) in
   let maxv6 = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" in
   let maxv4 = "254.254.254.254" in
-  let m = M.add (of_string_exn maxv4) "the greatest host v4" M.empty in
-  let m = M.add (of_string_exn "::0:0") "minv6" m in
-  let m = M.add (of_string_exn maxv6) "the greatest host v6" m in
-  let m = M.add (of_string_exn "::") "the least host v6" m in
-  let m = M.add (of_string_exn "1.0.0.1") "minv4" m in
-  let m = M.add (of_string_exn "1.0.0.1") "the least host v4" m in
-  assert_equal ~msg:"size" (M.cardinal m) 4;
-  let min_key, min_val = M.min_binding m in
+  let m = Map.add (of_string_exn maxv4) "the greatest host v4" Map.empty in
+  let m = Map.add (of_string_exn "::0:0") "minv6" m in
+  let m = Map.add (of_string_exn maxv6) "the greatest host v6" m in
+  let m = Map.add (of_string_exn "::") "the least host v6" m in
+  let m = Map.add (of_string_exn "1.0.0.1") "minv4" m in
+  let m = Map.add (of_string_exn "1.0.0.1") "the least host v4" m in
+  assert_equal ~msg:"size" (Map.cardinal m) 4;
+  let min_key, min_val = Map.min_binding m in
   assert_equal
     ~msg:("min is '" ^ min_val ^ "'")
     (min_key, min_val)
     (of_string_exn "1.0.0.1", "the least host v4");
-  assert_equal ~msg:"max" (M.max_binding m)
+  assert_equal ~msg:"max" (Map.max_binding m)
     (of_string_exn maxv6, "the greatest host v6")
 
 let test_prefix_mem () =

--- a/macaddr-cstruct.opam
+++ b/macaddr-cstruct.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.9.0"}
   "macaddr" {= version}
-  "cstruct" {>= "0.6.0"}
+  "cstruct" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This is a request for comments about extending the interface: I struggled in [happy-eyeballs](https://github.com/roburio/happy-eyeballs) which needs a Set of IPv4/IPv6 addresses and [dns](https://github.com/mirage/ocaml-dns) which uses these sets as well. Now, happy-eyeballs should be used in the dns resolver (and thus best to not have a dependency between happy-eyeballs and dns).

So, if anyone (@dinosaure @avsm anyone else from @mirage/core) has arguments to not provide the Set and Map submodules, please comment in this PR. Otherwise, I'll merge next week and cut a release to rebase happy-eyeballs and dns on top of these modules.