### PR TITLE
add host and subnet Seq.t iterators to V4/V6.Prefix

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -468,6 +468,7 @@ module B128 = struct
   let zero () = Bytes.make 16 '\x00'
   let max_int () = Bytes.make 16 '\xff'
   let compare = Bytes.compare
+  let equal = Bytes.equal
 
   let fold_left f a b =
     let a' = ref a in
@@ -567,6 +568,8 @@ module B128 = struct
           Bytes.set_uint8 b i sum))
       x y;
     if !carry <> 0 then raise Overflow else b
+
+  let add x y = try Some (add_exn x y) with Overflow -> None
 
   let sub_exn x y =
     if Bytes.compare x y = -1 then raise Overflow
@@ -1065,19 +1068,29 @@ module V6 = struct
 
     let subnets n (_, sz as cidr) =
       let rec iter_seq start stop steps =
-        if B128.compare start stop > 0 then Seq.Nil
-        else
+        if (B128.compare start stop) > 0 then (
+          Seq.Nil
+        )
+        else (
           let prefix = make n start in
-          let start_succ = B128.add_exn start steps in
-          if start_succ = B128.zero () then Seq.Cons (prefix, fun () -> Seq.Nil)
-          else Seq.Cons (prefix, fun () -> iter_seq start_succ stop steps)
+          if (B128.equal start stop) then
+            Seq.Cons (prefix, fun () -> Seq.Nil)
+          else (
+            match B128.add start steps with
+            | None -> Seq.Cons (prefix, fun () -> Seq.Nil)
+            | Some start_succ -> Seq.Cons (prefix, fun () -> iter_seq start_succ stop steps)
+            )
+          )
       in
       if sz > n || n > 128 then fun () -> Seq.Nil
-      else
-        let start = network cidr in
-        let stop = last cidr in
-        let steps = B128.(shift_right (hostmask cidr) (n - sz)) in
-        fun () -> iter_seq start stop steps
+      else (
+          let start = network cidr in
+          let stop = last cidr in
+          let steps =
+            B128.(add_exn (shift_right (hostmask cidr) (n - sz)) (B128.of_string_exn "00000000000000000000000000000001"))
+          in
+          fun () -> iter_seq start stop steps
+        )
   end
 
   (* TODO: This could be optimized with something trie-like *)

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -380,11 +380,44 @@ module V4 = struct
     let bits (_, sz) = sz
     let netmask subnet = mask (bits subnet)
 
+    let hostmask cidr = Int32.logxor (netmask cidr) 0xFF_FF_FF_FFl
+
     let first ((_, sz) as cidr) =
       if sz > 30 then network cidr else network cidr |> succ |> failwith_msg
 
     let last ((_, sz) as cidr) =
       if sz > 30 then broadcast cidr else broadcast cidr |> pred |> failwith_msg
+
+    let hosts ?(usable=true) ((_, sz) as cidr) =
+      let rec iter_seq start stop =
+        if compare (start, 32) (stop, 32) > 0 then Seq.Nil
+        else
+          match succ start with
+          | Ok start_succ -> Seq.Cons (start, fun () -> iter_seq start_succ stop)
+          | Error _ -> Seq.Cons (start, fun () -> Seq.Nil)
+      in
+      if usable && sz = 32 then fun () -> Seq.Nil else
+      let start, stop =
+        if usable then first cidr, last cidr
+        else network cidr, broadcast cidr
+      in
+      fun () -> iter_seq start stop
+
+    let subnets n (_, sz as cidr) =
+      let rec iter_seq start stop steps =
+        if compare (start, 32) (stop, 32) > 0 then Seq.Nil
+        else
+          let prefix = make n start in
+          let start_succ = Int32.add start steps in
+          if start_succ = 0l then Seq.Cons (prefix, fun () -> Seq.Nil)
+          else Seq.Cons (prefix, fun () -> iter_seq start_succ stop steps)
+      in
+      if sz > n || n > 32 then fun () -> Seq.Nil
+      else
+        let start = network cidr in
+        let stop = broadcast cidr in
+        let steps = Int32.add (hostmask cidr) 1l >|> (n - sz) in
+        fun () -> iter_seq start stop steps
   end
 
   (* TODO: this could be optimized with something trie-like *)
@@ -559,6 +592,11 @@ module B128 = struct
   let logor x y =
     let b = zero () in
     iteri_right2 (fun i x y -> Bytes.set_uint8 b i (x lor y)) x y;
+    b
+
+  let logxor x y =
+    let b = zero () in
+    iteri_right2 (fun i x y -> Bytes.set_uint8 b i (x lxor y)) x y;
     b
 
   let lognot x =
@@ -1001,12 +1039,45 @@ module V6 = struct
     let bits (_, sz) = sz
     let netmask subnet = mask (bits subnet)
 
+    let hostmask cidr = B128.logxor (netmask cidr) (B128.max_int ())
+
     let first ((_, sz) as cidr) =
       if sz > 126 then network cidr else network cidr |> succ |> failwith_msg
 
     let last ((_, sz) as cidr) =
       let ffff = B128.max_int () in
       logor (network cidr) (B128.shift_right ffff sz)
+
+    let hosts ?(usable=true) ((_, sz) as cidr) =
+      let rec iter_seq start stop =
+        if B128.compare start stop > 0 then Seq.Nil
+        else
+          match succ start with
+          | Ok start_succ -> Seq.Cons (start, fun () -> iter_seq start_succ stop)
+          | Error _ -> Seq.Cons (start, fun () -> Seq.Nil)
+      in
+      if usable && sz = 128 then fun () -> Seq.Nil else
+      let start, stop =
+        if usable then first cidr, last cidr
+        else network cidr, last cidr
+      in
+      fun () -> iter_seq start stop
+
+    let subnets n (_, sz as cidr) =
+      let rec iter_seq start stop steps =
+        if B128.compare start stop > 0 then Seq.Nil
+        else
+          let prefix = make n start in
+          let start_succ = B128.add_exn start steps in
+          if start_succ = B128.zero () then Seq.Cons (prefix, fun () -> Seq.Nil)
+          else Seq.Cons (prefix, fun () -> iter_seq start_succ stop steps)
+      in
+      if sz > n || n > 128 then fun () -> Seq.Nil
+      else
+        let start = network cidr in
+        let stop = last cidr in
+        let steps = B128.(shift_right (hostmask cidr) (n - sz)) in
+        fun () -> iter_seq start stop steps
   end
 
   (* TODO: This could be optimized with something trie-like *)
@@ -1277,4 +1348,12 @@ module Prefix = struct
   let last = function
     | V4 p -> V4 (V4.Prefix.last p)
     | V6 p -> V6 (V6.Prefix.last p)
+
+  let hosts ?(usable=true) = function
+    | V4 p -> V4 (V4.Prefix.hosts ~usable p)
+    | V6 p -> V6 (V6.Prefix.hosts ~usable p)
+
+  let subnets n = function
+    | V4 p -> V4 (V4.Prefix.subnets n p)
+    | V6 p -> V6 (V6.Prefix.subnets n p)
 end

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -296,6 +296,15 @@ module V4 : sig
     val last : t -> addr
     (** [last cidr] is last valid unicast address in this [cidr]. *)
 
+    val hosts : ?usable:bool -> t -> addr Seq.t
+    (** [hosts cidr] is the sequence of host addresses in this [cidr]. By
+        default, network and broadcast addresses are omitted. This can be
+        changed by setting [usable] to false. *)
+
+    val subnets : int -> t -> t Seq.t
+    (** [subnets n cidr] is the sequence of subnets of [cidr] with a prefix
+        length of [n]. *)
+
     include Map.OrderedType with type t := t
   end
 
@@ -568,6 +577,15 @@ module V6 : sig
     val last : t -> addr
     (** [last subnet] is last valid unicast address in this [subnet]. *)
 
+    val hosts : ?usable:bool -> t -> addr Seq.t
+    (** [hosts subnet] is the sequence of host addresses in this [subnet]. By
+        default the Subnet-Router anycast address is omitted. This can be
+        changed by setting [usable] to false. *)
+
+    val subnets : int -> t -> t Seq.t
+    (** [subnets n subnet] is the sequence of subnets of [subnet] with a prefix
+        length of [n]. *)
+
     include Map.OrderedType with type t := t
   end
 
@@ -764,6 +782,16 @@ module Prefix : sig
 
   val last : t -> addr
   (** [last subnet] is last valid unicast address in this [subnet]. *)
+
+  val hosts : ?usable:bool -> t -> (V4.t Seq.t, V6.t Seq.t) v4v6
+  (** [hosts cidr] is the sequence of host addresses in this [cidr]. By default,
+      the network and broadcast addresses are omitted for IPv4. In the case of
+      IPv6, the Subnet-Router anycast address is omitted by default. This can be
+      changed by setting [usable] to false. *)
+
+  val subnets : int -> t -> (V4.Prefix.t Seq.t, V6.Prefix.t Seq.t) v4v6
+  (** [subnets n cidr] is the sequence of subnets of [cidr] with a prefix length
+      of [n]. *)
 
   include Map.OrderedType with type t := t
 end

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -25,7 +25,6 @@ let bad_char i s =
   error s (Printf.sprintf "invalid character '%c' at %d" s.[i] i)
 
 let string_of_list f l = "[" ^ (List.map f l |> String.concat "; ") ^ "]"
-
 let ( >>= ) v f = match v with Ok v -> f v | Error _ as e -> e
 
 let assert_raises ~msg exn test_fn =
@@ -456,28 +455,55 @@ module Test_v4 = struct
   let test_hosts () =
     let nets =
       [
-        ("255.255.255.255/32", ["255.255.255.255"], false);
+        ("255.255.255.255/32", [ "255.255.255.255" ], false);
         ("255.255.255.255/32", [], true);
-        ("255.255.255.254/31", ["255.255.255.254"; "255.255.255.255"], true);
-        ("255.255.255.254/31", ["255.255.255.254"; "255.255.255.255"], false);
-        ("255.255.255.252/30", ["255.255.255.253"; "255.255.255.254"], true);
-        ("255.255.255.252/30", ["255.255.255.252"; "255.255.255.253";
-        "255.255.255.254"; "255.255.255.255"], false);
-        ("192.0.2.0/29", ["192.0.2.0"; "192.0.2.1"; "192.0.2.2"; "192.0.2.3";
-        "192.0.2.4"; "192.0.2.5"; "192.0.2.6"; "192.0.2.7"], false);
-        ("192.0.2.0/29", ["192.0.2.1"; "192.0.2.2"; "192.0.2.3";
-        "192.0.2.4";"192.0.2.5";"192.0.2.6";], true);
+        ("255.255.255.254/31", [ "255.255.255.254"; "255.255.255.255" ], true);
+        ("255.255.255.254/31", [ "255.255.255.254"; "255.255.255.255" ], false);
+        ("255.255.255.252/30", [ "255.255.255.253"; "255.255.255.254" ], true);
+        ( "255.255.255.252/30",
+          [
+            "255.255.255.252";
+            "255.255.255.253";
+            "255.255.255.254";
+            "255.255.255.255";
+          ],
+          false );
+        ( "192.0.2.0/29",
+          [
+            "192.0.2.0";
+            "192.0.2.1";
+            "192.0.2.2";
+            "192.0.2.3";
+            "192.0.2.4";
+            "192.0.2.5";
+            "192.0.2.6";
+            "192.0.2.7";
+          ],
+          false );
+        ( "192.0.2.0/29",
+          [
+            "192.0.2.1";
+            "192.0.2.2";
+            "192.0.2.3";
+            "192.0.2.4";
+            "192.0.2.5";
+            "192.0.2.6";
+          ],
+          true );
       ]
     in
     List.iter
       (fun (net, hosts, usable_flag) ->
         let hosts = List.map V4.of_string_exn hosts in
-        let hosts_list = List.of_seq (V4.Prefix.hosts ~usable:usable_flag
-          (V4.Prefix.of_string_exn net)) in
+        let hosts_list =
+          List.of_seq
+            (V4.Prefix.hosts ~usable:usable_flag (V4.Prefix.of_string_exn net))
+        in
         let msg =
           Printf.sprintf
-            "incorrect sequence of hosts for %s (usable_flag: %b): %s"
-            net usable_flag (string_of_list V4.to_string hosts_list)
+            "incorrect sequence of hosts for %s (usable_flag: %b): %s" net
+            usable_flag
+            (string_of_list V4.to_string hosts_list)
         in
         assert_equal ~msg hosts_list hosts)
       nets
@@ -487,24 +513,31 @@ module Test_v4 = struct
       [
         ("255.255.255.255/32", [], 24);
         ("192.0.2.0/24", [], 23);
-        ("255.255.255.255/32", ["255.255.255.255/32"], 32);
-        ("255.255.255.254/31", ["255.255.255.254/32"; "255.255.255.255/32"], 32);
-        ("255.255.255.252/30", ["255.255.255.252/31"; "255.255.255.254/31"], 31);
-        ("192.0.2.0/29", ["192.0.2.0/30"; "192.0.2.4/30"], 30);
-        ("192.0.2.0/24", ["192.0.2.0/25"; "192.0.2.128/25"], 25);
-        ("192.0.2.0/24", ["192.0.2.0/24"], 24);
-        ("10.0.0.0/8", ["10.0.0.0/9"; "10.128.0.0/9"], 9);
+        ("255.255.255.255/32", [ "255.255.255.255/32" ], 32);
+        ( "255.255.255.254/31",
+          [ "255.255.255.254/32"; "255.255.255.255/32" ],
+          32 );
+        ( "255.255.255.252/30",
+          [ "255.255.255.252/31"; "255.255.255.254/31" ],
+          31 );
+        ("192.0.2.0/29", [ "192.0.2.0/30"; "192.0.2.4/30" ], 30);
+        ("192.0.2.0/24", [ "192.0.2.0/25"; "192.0.2.128/25" ], 25);
+        ("192.0.2.0/24", [ "192.0.2.0/24" ], 24);
+        ("10.0.0.0/8", [ "10.0.0.0/9"; "10.128.0.0/9" ], 9);
       ]
     in
     List.iter
       (fun (net, subnets, sz) ->
         let subnets = List.map V4.Prefix.of_string_exn subnets in
         let subnets_list =
-          List.of_seq (V4.Prefix.subnets sz (V4.Prefix.of_string_exn net)) in
+          List.of_seq (V4.Prefix.subnets sz (V4.Prefix.of_string_exn net))
+        in
         let msg =
           Printf.sprintf
             "incorrect sequence of subnets for %s (prefix length: %i): %s" net
-            sz (string_of_list V4.Prefix.to_string subnets_list) in
+            sz
+            (string_of_list V4.Prefix.to_string subnets_list)
+        in
         assert_equal ~msg subnets_list subnets)
       nets
 
@@ -982,27 +1015,39 @@ module Test_v6 = struct
   let test_hosts () =
     let nets =
       [
-        ("2001:db8:0:ffff::/128", ["2001:db8:0:ffff::"], false);
+        ("2001:db8:0:ffff::/128", [ "2001:db8:0:ffff::" ], false);
         ("2001:db8:0:ffff::/128", [], true);
-        ("2001:db8:0:ffff::/127", ["2001:db8:0:ffff::"; "2001:db8:0:ffff::1"],
-         false);
-        ("2001:db8:0:ffff::/127", ["2001:db8:0:ffff::"; "2001:db8:0:ffff::1"],
-         true);
-        ("2001:db8:0:ffff::/126", ["2001:db8:0:ffff::"; "2001:db8:0:ffff::1";
-         "2001:db8:0:ffff::2"; "2001:db8:0:ffff::3"], false);
-        ("2001:db8:0:ffff::/126", ["2001:db8:0:ffff::1"; "2001:db8:0:ffff::2";
-         "2001:db8:0:ffff::3"], true);
+        ( "2001:db8:0:ffff::/127",
+          [ "2001:db8:0:ffff::"; "2001:db8:0:ffff::1" ],
+          false );
+        ( "2001:db8:0:ffff::/127",
+          [ "2001:db8:0:ffff::"; "2001:db8:0:ffff::1" ],
+          true );
+        ( "2001:db8:0:ffff::/126",
+          [
+            "2001:db8:0:ffff::";
+            "2001:db8:0:ffff::1";
+            "2001:db8:0:ffff::2";
+            "2001:db8:0:ffff::3";
+          ],
+          false );
+        ( "2001:db8:0:ffff::/126",
+          [ "2001:db8:0:ffff::1"; "2001:db8:0:ffff::2"; "2001:db8:0:ffff::3" ],
+          true );
       ]
     in
     List.iter
       (fun (net, hosts, usable_flag) ->
         let hosts = List.map V6.of_string_exn hosts in
-        let hosts_list = List.of_seq (V6.Prefix.hosts ~usable:usable_flag
-          (V6.Prefix.of_string_exn net)) in
+        let hosts_list =
+          List.of_seq
+            (V6.Prefix.hosts ~usable:usable_flag (V6.Prefix.of_string_exn net))
+        in
         let msg =
           Printf.sprintf
-            "incorrect sequence of hosts for %s (usable_flag: %b): %s"
-            net usable_flag (string_of_list V6.to_string hosts_list)
+            "incorrect sequence of hosts for %s (usable_flag: %b): %s" net
+            usable_flag
+            (string_of_list V6.to_string hosts_list)
         in
         assert_equal ~msg hosts_list hosts)
       nets
@@ -1012,31 +1057,49 @@ module Test_v6 = struct
       [
         ("2001:db8:0:ffff::/128", [], 127);
         ("2001:db8:0:ffff::/64", [], 63);
-        ("2001:db8:0:ffff::/128", ["2001:db8:0:ffff::/128"], 128);
-        ("2001:db8:0:ffff::/127", ["2001:db8:0:ffff::/128";
-         "2001:db8:0:ffff::1/128"], 128);
-        ("::/0", ["::/1"; "8000::/1"], 1);
-        ("::/0", ["::/2"; "4000::/2"; "8000::/2"; "c000::/2"], 2);
-        ("2001:db8:0:ffff::/126", ["2001:db8:0:ffff::/127";
-         "2001:db8:0:ffff::2/127";], 127);
-        ("2001:db8:0:fff0::/60", ["2001:db8:0:fff0::/64";
-         "2001:db8:0:fff1::/64"; "2001:db8:0:fff2::/64"; "2001:db8:0:fff3::/64";
-         "2001:db8:0:fff4::/64"; "2001:db8:0:fff5::/64"; "2001:db8:0:fff6::/64";
-         "2001:db8:0:fff7::/64"; "2001:db8:0:fff8::/64"; "2001:db8:0:fff9::/64";
-         "2001:db8:0:fffa::/64"; "2001:db8:0:fffb::/64"; "2001:db8:0:fffc::/64";
-         "2001:db8:0:fffd::/64"; "2001:db8:0:fffe::/64"; "2001:db8:0:ffff::/64";
-         ], 64);
+        ("2001:db8:0:ffff::/128", [ "2001:db8:0:ffff::/128" ], 128);
+        ( "2001:db8:0:ffff::/127",
+          [ "2001:db8:0:ffff::/128"; "2001:db8:0:ffff::1/128" ],
+          128 );
+        ("::/0", [ "::/1"; "8000::/1" ], 1);
+        ("::/0", [ "::/2"; "4000::/2"; "8000::/2"; "c000::/2" ], 2);
+        ( "2001:db8:0:ffff::/126",
+          [ "2001:db8:0:ffff::/127"; "2001:db8:0:ffff::2/127" ],
+          127 );
+        ( "2001:db8:0:fff0::/60",
+          [
+            "2001:db8:0:fff0::/64";
+            "2001:db8:0:fff1::/64";
+            "2001:db8:0:fff2::/64";
+            "2001:db8:0:fff3::/64";
+            "2001:db8:0:fff4::/64";
+            "2001:db8:0:fff5::/64";
+            "2001:db8:0:fff6::/64";
+            "2001:db8:0:fff7::/64";
+            "2001:db8:0:fff8::/64";
+            "2001:db8:0:fff9::/64";
+            "2001:db8:0:fffa::/64";
+            "2001:db8:0:fffb::/64";
+            "2001:db8:0:fffc::/64";
+            "2001:db8:0:fffd::/64";
+            "2001:db8:0:fffe::/64";
+            "2001:db8:0:ffff::/64";
+          ],
+          64 );
       ]
     in
     List.iter
       (fun (net, subnets, sz) ->
         let subnets = List.map V6.Prefix.of_string_exn subnets in
         let subnets_list =
-          List.of_seq (V6.Prefix.subnets sz (V6.Prefix.of_string_exn net)) in
+          List.of_seq (V6.Prefix.subnets sz (V6.Prefix.of_string_exn net))
+        in
         let msg =
           Printf.sprintf
             "incorrect sequence of subnets for %s (prefix length: %i): %s" net
-            sz (string_of_list V6.Prefix.to_string subnets_list) in
+            sz
+            (string_of_list V6.Prefix.to_string subnets_list)
+        in
         assert_equal ~msg subnets_list subnets)
       nets
 

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -24,6 +24,8 @@ let need_more s = error s "not enough data"
 let bad_char i s =
   error s (Printf.sprintf "invalid character '%c' at %d" s.[i] i)
 
+let string_of_list f l = "[" ^ (List.map f l |> String.concat "; ") ^ "]"
+
 let ( >>= ) v f = match v with Ok v -> f v | Error _ as e -> e
 
 let assert_raises ~msg exn test_fn =
@@ -451,6 +453,61 @@ module Test_v4 = struct
         assert_raises ~msg:addr exn (fun () -> V4.Prefix.of_string_exn addr))
       bad_addrs
 
+  let test_hosts () =
+    let nets =
+      [
+        ("255.255.255.255/32", ["255.255.255.255"], false);
+        ("255.255.255.255/32", [], true);
+        ("255.255.255.254/31", ["255.255.255.254"; "255.255.255.255"], true);
+        ("255.255.255.254/31", ["255.255.255.254"; "255.255.255.255"], false);
+        ("255.255.255.252/30", ["255.255.255.253"; "255.255.255.254"], true);
+        ("255.255.255.252/30", ["255.255.255.252"; "255.255.255.253";
+        "255.255.255.254"; "255.255.255.255"], false);
+        ("192.0.2.0/29", ["192.0.2.0"; "192.0.2.1"; "192.0.2.2"; "192.0.2.3";
+        "192.0.2.4"; "192.0.2.5"; "192.0.2.6"; "192.0.2.7"], false);
+        ("192.0.2.0/29", ["192.0.2.1"; "192.0.2.2"; "192.0.2.3";
+        "192.0.2.4";"192.0.2.5";"192.0.2.6";], true);
+      ]
+    in
+    List.iter
+      (fun (net, hosts, usable_flag) ->
+        let hosts = List.map V4.of_string_exn hosts in
+        let hosts_list = List.of_seq (V4.Prefix.hosts ~usable:usable_flag
+          (V4.Prefix.of_string_exn net)) in
+        let msg =
+          Printf.sprintf
+            "incorrect sequence of hosts for %s (usable_flag: %b): %s"
+            net usable_flag (string_of_list V4.to_string hosts_list)
+        in
+        assert_equal ~msg hosts_list hosts)
+      nets
+
+  let test_subnets () =
+    let nets =
+      [
+        ("255.255.255.255/32", [], 24);
+        ("192.0.2.0/24", [], 23);
+        ("255.255.255.255/32", ["255.255.255.255/32"], 32);
+        ("255.255.255.254/31", ["255.255.255.254/32"; "255.255.255.255/32"], 32);
+        ("255.255.255.252/30", ["255.255.255.252/31"; "255.255.255.254/31"], 31);
+        ("192.0.2.0/29", ["192.0.2.0/30"; "192.0.2.4/30"], 30);
+        ("192.0.2.0/24", ["192.0.2.0/25"; "192.0.2.128/25"], 25);
+        ("192.0.2.0/24", ["192.0.2.0/24"], 24);
+        ("10.0.0.0/8", ["10.0.0.0/9"; "10.128.0.0/9"], 9);
+      ]
+    in
+    List.iter
+      (fun (net, subnets, sz) ->
+        let subnets = List.map V4.Prefix.of_string_exn subnets in
+        let subnets_list =
+          List.of_seq (V4.Prefix.subnets sz (V4.Prefix.of_string_exn net)) in
+        let msg =
+          Printf.sprintf
+            "incorrect sequence of subnets for %s (prefix length: %i): %s" net
+            sz (string_of_list V4.Prefix.to_string subnets_list) in
+        assert_equal ~msg subnets_list subnets)
+      nets
+
   let suite =
     "Test V4"
     >::: [
@@ -481,6 +538,8 @@ module Test_v4 = struct
            "prefix_first_last" >:: test_prefix_first_last;
            "reject_octal" >:: test_reject_octal;
            "reject_prefix_octal" >:: test_reject_prefix_octal;
+           "hosts" >:: test_hosts;
+           "subnets" >:: test_subnets;
          ]
 end
 
@@ -920,6 +979,67 @@ module Test_v6 = struct
     assert_equal ~msg:"last ::aaa0/128" (ip_of_string "::aaa0")
       (last @@ of_string_exn "::aaa0/128")
 
+  let test_hosts () =
+    let nets =
+      [
+        ("2001:db8:0:ffff::/128", ["2001:db8:0:ffff::"], false);
+        ("2001:db8:0:ffff::/128", [], true);
+        ("2001:db8:0:ffff::/127", ["2001:db8:0:ffff::"; "2001:db8:0:ffff::1"],
+         false);
+        ("2001:db8:0:ffff::/127", ["2001:db8:0:ffff::"; "2001:db8:0:ffff::1"],
+         true);
+        ("2001:db8:0:ffff::/126", ["2001:db8:0:ffff::"; "2001:db8:0:ffff::1";
+         "2001:db8:0:ffff::2"; "2001:db8:0:ffff::3"], false);
+        ("2001:db8:0:ffff::/126", ["2001:db8:0:ffff::1"; "2001:db8:0:ffff::2";
+         "2001:db8:0:ffff::3"], true);
+      ]
+    in
+    List.iter
+      (fun (net, hosts, usable_flag) ->
+        let hosts = List.map V6.of_string_exn hosts in
+        let hosts_list = List.of_seq (V6.Prefix.hosts ~usable:usable_flag
+          (V6.Prefix.of_string_exn net)) in
+        let msg =
+          Printf.sprintf
+            "incorrect sequence of hosts for %s (usable_flag: %b): %s"
+            net usable_flag (string_of_list V6.to_string hosts_list)
+        in
+        assert_equal ~msg hosts_list hosts)
+      nets
+
+  let test_subnets () =
+    let nets =
+      [
+        ("2001:db8:0:ffff::/128", [], 127);
+        ("2001:db8:0:ffff::/64", [], 63);
+        ("2001:db8:0:ffff::/128", ["2001:db8:0:ffff::/128"], 128);
+        ("2001:db8:0:ffff::/127", ["2001:db8:0:ffff::/128";
+         "2001:db8:0:ffff::1/128"], 128);
+        ("::/0", ["::/1"; "8000::/1"], 1);
+        ("::/0", ["::/2"; "4000::/2"; "8000::/2"; "c000::/2"], 2);
+        ("2001:db8:0:ffff::/126", ["2001:db8:0:ffff::/127";
+         "2001:db8:0:ffff::2/127";], 127);
+        ("2001:db8:0:fff0::/60", ["2001:db8:0:fff0::/64";
+         "2001:db8:0:fff1::/64"; "2001:db8:0:fff2::/64"; "2001:db8:0:fff3::/64";
+         "2001:db8:0:fff4::/64"; "2001:db8:0:fff5::/64"; "2001:db8:0:fff6::/64";
+         "2001:db8:0:fff7::/64"; "2001:db8:0:fff8::/64"; "2001:db8:0:fff9::/64";
+         "2001:db8:0:fffa::/64"; "2001:db8:0:fffb::/64"; "2001:db8:0:fffc::/64";
+         "2001:db8:0:fffd::/64"; "2001:db8:0:fffe::/64"; "2001:db8:0:ffff::/64";
+         ], 64);
+      ]
+    in
+    List.iter
+      (fun (net, subnets, sz) ->
+        let subnets = List.map V6.Prefix.of_string_exn subnets in
+        let subnets_list =
+          List.of_seq (V6.Prefix.subnets sz (V6.Prefix.of_string_exn net)) in
+        let msg =
+          Printf.sprintf
+            "incorrect sequence of subnets for %s (prefix length: %i): %s" net
+            sz (string_of_list V6.Prefix.to_string subnets_list) in
+        assert_equal ~msg subnets_list subnets)
+      nets
+
   let suite =
     "Test V6"
     >::: [
@@ -947,6 +1067,8 @@ module Test_v6 = struct
            "link_address_of_mac" >:: test_link_address_of_mac;
            "succ_pred" >:: test_succ_pred;
            "first_last" >:: test_first_last;
+           "hosts" >:: test_hosts;
+           "subnets" >:: test_subnets;
          ]
 end
 


### PR DESCRIPTION
This PR adds host and subnet iterators to the V4/V6.Prefix modules. At the moment, the implementation of the IPv6 subnet iterator is missing, hence the WIP. But I wanted to open the PR to get some feedback, especially regarding exceptions and the code in general.

Currently, invalid parameters to the subnets function just return a Seq.Nil instead of an exception. I didn't want
to wrap them into options or results, which would be a bit heavier to unpack for the users of the library.
But maybe raising an exception for arguments that are clearly out of bounds, like a prefix length bellow 0
or above 32 for IPv4 for example would be fine.

The implementation mimics the behavior of the methods in Python's ipaddress module.

I haven't exposed the hostmask functions in the signature, because I didn't want to clutter the interface and
I'm not sure if they are useful for other use-cases.