### PR TITLE
remove stdlib-shims dependency, require OCaml 4.08

### DIFF
--- a/ipaddr-cstruct.opam
+++ b/ipaddr-cstruct.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.9.0"}
   "ipaddr" {= version}
   "cstruct" {>= "6.0.0"}

--- a/ipaddr-sexp.opam
+++ b/ipaddr-sexp.opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.9.0"}
   "ipaddr" {= version}
   "ipaddr-cstruct" {with-test & = version}

--- a/ipaddr.opam
+++ b/ipaddr.opam
@@ -27,10 +27,9 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.9.0"}
   "macaddr" {= version}
-  "stdlib-shims"
   "domain-name" {>= "0.3.0"}
   "ounit" {with-test}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name ipaddr)
  (public_name ipaddr)
  (modules ipaddr)
- (libraries macaddr domain-name stdlib-shims))
+ (libraries macaddr domain-name))
 
 (library
  (name macaddr)

--- a/macaddr-cstruct.opam
+++ b/macaddr-cstruct.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.9.0"}
   "macaddr" {= version}
   "cstruct" {>= "6.0.0"}

--- a/macaddr-sexp.opam
+++ b/macaddr-sexp.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.9.0"}
   "macaddr" {= version}
   "macaddr-cstruct" {with-test & = version}

--- a/macaddr.opam
+++ b/macaddr.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.9.0"}
   "ounit" {with-test}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}


### PR DESCRIPTION
See https://github.com/mirage/ocaml-cstruct/pull/298 for a similar discussion. With OCaml 5.00 on the horizon, I'm keen to drop support for arcane OCaml releases, and minimize the dependency cone (also see https://discuss.ocaml.org/t/lwt-informal-user-survey/9666 which may drop < 4.08 for lwt).