### PR TITLE
use Bytes.t as data type for IPv6 addresses

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.0
+version = 0.25.1
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -472,7 +472,9 @@ module B128 = struct
     for i = 15 downto 0 do
       l := Printf.sprintf "%.2x" (Bytes.get_uint8 b i) :: !l
     done;
-    String.concat "" !l[@@ocaml.warning "-32"] (* used in the tests *)
+    String.concat "" !l
+    [@@ocaml.warning "-32"]
+  (* used in the tests *)
 
   let of_int64 (a, b) =
     let b' = zero () in
@@ -601,16 +603,16 @@ module B128 = struct
         let b = zero () in
         let shift_bytes, shift_bits = (n / 8, n mod 8) in
         (if shift_bits = 0 then Bytes.blit x 0 b shift_bytes (16 - shift_bytes)
-        else
-          let carry = ref 0 in
-          for i = 0 to 15 - shift_bytes do
-            let x' = Bytes.get_uint8 x i in
-            let new_carry = Byte.get_lsbits shift_bits x' in
-            let shifted_value = x' lsr shift_bits in
-            let new_value = Byte.set_msbits shift_bits !carry shifted_value in
-            Bytes.set_uint8 b (i + shift_bytes) new_value;
-            carry := new_carry
-          done);
+         else
+           let carry = ref 0 in
+           for i = 0 to 15 - shift_bytes do
+             let x' = Bytes.get_uint8 x i in
+             let new_carry = Byte.get_lsbits shift_bits x' in
+             let shifted_value = x' lsr shift_bits in
+             let new_value = Byte.set_msbits shift_bits !carry shifted_value in
+             Bytes.set_uint8 b (i + shift_bytes) new_value;
+             carry := new_carry
+           done);
         b
     | _ -> raise (Invalid_argument "n must be >= 0 && <= 128")
 
@@ -622,16 +624,16 @@ module B128 = struct
         let b = zero () in
         let shift_bytes, shift_bits = (n / 8, n mod 8) in
         (if shift_bits = 0 then Bytes.blit x shift_bytes b 0 (16 - shift_bytes)
-        else
-          let carry = ref 0 in
-          for i = 15 downto 0 + shift_bytes do
-            let x' = Bytes.get_uint8 x i in
-            let new_carry = Byte.get_msbits shift_bits x' in
-            let shifted_value = x' lsl shift_bits in
-            let new_value = shifted_value lor !carry in
-            Bytes.set_uint8 b (i - shift_bytes) new_value;
-            carry := new_carry
-          done);
+         else
+           let carry = ref 0 in
+           for i = 15 downto 0 + shift_bytes do
+             let x' = Bytes.get_uint8 x i in
+             let new_carry = Byte.get_msbits shift_bits x' in
+             let shifted_value = x' lsl shift_bits in
+             let new_value = shifted_value lor !carry in
+             Bytes.set_uint8 b (i - shift_bytes) new_value;
+             carry := new_carry
+           done);
         b
     | _ -> raise (Invalid_argument "n must be >= 0 && <= 128")
 

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -639,7 +639,7 @@ module B128 = struct
     if Bytes.length b' + off > Bytes.length byte then
       raise
         (Parse_error
-           ("larger including offset than target bytes", String.of_bytes b'))
+           ("larger including offset than target bytes", Bytes.to_string b'))
     else Bytes.blit b' 0 byte off (Bytes.length b')
 
   let succ b =

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -634,13 +634,19 @@ module Test_v6 = struct
       addr
 
   let test_int64_rt () =
-    let ((a, b) as addr) =
-      0x2a01_04f9_c011_87adL, 0x0_0_0_0L
+    let tests =
+      [
+        (0x2a01_04f9_c011_87adL, 0x0_0_0_0L);
+        (0x0000_0000_8000_0000L, 0x0_0_0_0L);
+      ]
     in
-    assert_equal
-      ~msg:(Printf.sprintf "%016Lx %016Lx" a b)
-      V6.(to_int64 (of_int64 addr))
-      addr
+    List.iter
+      (fun ((a, b) as addr) ->
+        assert_equal
+          ~msg:(Printf.sprintf "%016Lx %016Lx" a b)
+          V6.(to_int64 (of_int64 addr))
+          addr)
+      tests
 
   let test_prefix_string_rt () =
     let subnets =

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -633,6 +633,15 @@ module Test_v6 = struct
       V6.(to_int32 (of_int32 addr))
       addr
 
+  let test_int64_rt () =
+    let ((a, b) as addr) =
+      0x2a01_04f9_c011_87adL, 0x0_0_0_0L
+    in
+    assert_equal
+      ~msg:(Printf.sprintf "%016Lx %016Lx" a b)
+      V6.(to_int64 (of_int64 addr))
+      addr
+
   let test_prefix_string_rt () =
     let subnets =
       [
@@ -917,6 +926,7 @@ module Test_v6 = struct
            "cstruct_rt" >:: test_cstruct_rt;
            "cstruct_rt_bad" >:: test_cstruct_rt_bad;
            "int32_rt" >:: test_int32_rt;
+           "int64_rt" >:: test_int64_rt;
            "prefix_string_rt" >:: test_prefix_string_rt;
            "prefix_string_rt_bad" >:: test_prefix_string_rt_bad;
            "network_address_rt" >:: test_network_address_rt;

--- a/lib_test/test_ipaddr_b128.ml
+++ b/lib_test/test_ipaddr_b128.ml
@@ -16,35 +16,167 @@
  *)
 
 open OUnit
+module B128 = Ipaddr_internal.B128
+
+(* copied from test_ipaddr.ml *)
+let assert_raises ~msg exn test_fn =
+  assert_raises ~msg exn (fun () ->
+      try test_fn ()
+      with rtexn ->
+        if exn <> rtexn then (
+          Printf.eprintf "Stacktrace for '%s':\n%!" msg;
+          Printexc.print_backtrace stderr);
+        raise rtexn)
+
+let assert_equal = assert_equal ~printer:Ipaddr_internal.B128.to_string
+
+let test_addition () =
+  (* simple addition *)
+  let d1 = B128.zero () in
+  let d2 = B128.of_string_exn "00000000000000000000000000000001" in
+  assert_equal ~msg:"adding one to zero is one" d2 (B128.add_exn d1 d2);
+
+  (* addition carry *)
+  let d1 = B128.of_string_exn "000000000000000000ff000000000000" in
+  let d2 = B128.of_string_exn "00000000000000000001000000000000" in
+  let d3 = B128.of_string_exn "00000000000000000100000000000000" in
+  assert_equal ~msg:"test addition carry over" d3 (B128.add_exn d1 d2);
+
+  (* adding one to max_int overflows *)
+  let d1 = B128.max_int () in
+  let d2 = B128.of_string_exn "00000000000000000000000000000001" in
+  assert_raises ~msg:"adding one to max_int overflows" B128.Overflow (fun () ->
+      B128.add_exn d1 d2)
+
+let test_subtraction () =
+  (* simple subtraction *)
+  let d1 = B128.of_string_exn "00000000000000000000000000000001" in
+  let d2 = B128.of_string_exn "00000000000000000000000000000001" in
+  let d3 = B128.zero () in
+  assert_equal ~msg:"subtracting one from one is zero" d3 (B128.sub_exn d1 d2);
+
+  (* subtract carry *)
+  let d1 = B128.of_string_exn "00000000000000000000000000000300" in
+  let d2 = B128.of_string_exn "0000000000000000000000000000002a" in
+  let d3 = B128.of_string_exn "000000000000000000000000000002d6" in
+  assert_equal ~msg:"test subtraction carry over" d3 (B128.sub_exn d1 d2);
+
+  (* subtracting one from min_int overflows *)
+  let d1 = B128.min_int () in
+  let d2 = B128.of_string_exn "00000000000000000000000000000001" in
+  assert_raises ~msg:"subtracting one from min_int overflows" B128.Overflow
+    (fun () -> B128.sub_exn d1 d2)
+
+let test_of_to_string () =
+  let s = "ff000000000000004200000000000001" in
+  OUnit.assert_equal ~msg:"input of of_string is equal to output of to_string" s
+    (B128.of_string_exn s |> B128.to_string)
+
+let test_lognot () =
+  let d1 = B128.of_string_exn "00000000000000000000000000000001" in
+  let d2 = B128.of_string_exn "fffffffffffffffffffffffffffffffe" in
+  assert_equal ~msg:"lognot inverts bits" d2 (B128.lognot d1)
+
+let test_shift_left () =
+  (* bit shift count, input, expected output *)
+  let test_shifts =
+    [
+      (1, "f0000000000000000000000000000000", "e0000000000000000000000000000000");
+      (1, "0000000000000000000000000000000f", "0000000000000000000000000000001e");
+      (1, "00000000000000000000000000000001", "00000000000000000000000000000002");
+      (2, "f0000000000000000000000000000000", "c0000000000000000000000000000000");
+      (2, "0000000000000000000000000000ffff", "0000000000000000000000000003fffc");
+      (8, "00000000000000000000000000000100", "00000000000000000000000000010000");
+      (9, "f0000000000000000000000000000000", "00000000000000000000000000000000");
+      ( 64,
+        "00000000000000000000000000000001",
+        "00000000000000010000000000000000" );
+      ( 127,
+        "00000000000000000000000000000001",
+        "80000000000000000000000000000000" );
+      ( 128,
+        "00000000000000000000000000000001",
+        "00000000000000000000000000000000" );
+    ]
+  in
+  List.iter
+    (fun (bits, input_value, expected_output) ->
+      assert_equal
+        ~msg:(Printf.sprintf "shift left by %i" bits)
+        (B128.of_string_exn expected_output)
+        (B128.shift_left (B128.of_string_exn input_value) bits))
+    test_shifts
 
 let test_shift_right () =
-  let open Ipaddr_internal in
-  let open V6 in
-  let printer = function
-    | Ok v -> Printf.sprintf "Ok %s" (to_string v)
-    | Error (`Msg e) -> Printf.sprintf "Error `Msg \"%s\"" e
+  (* (bit shift count, input, expected output) *)
+  let test_shifts =
+    [
+      (1, "f0000000000000000000000000000000", "78000000000000000000000000000000");
+      (2, "f0000000000000000000000000000000", "3c000000000000000000000000000000");
+      (2, "0000000000000000000000000000ffff", "00000000000000000000000000003fff");
+      (2, "000000000000000000000000000ffff0", "0000000000000000000000000003fffc");
+      (8, "00000000000000000000000000000100", "00000000000000000000000000000001");
+      (9, "f0000000000000000000000000000000", "00780000000000000000000000000000");
+      ( 32,
+        "000000000000000000000000ffffffff",
+        "00000000000000000000000000000000" );
+      ( 32,
+        "0000000000000000aaaabbbbffffffff",
+        "000000000000000000000000aaaabbbb" );
+      ( 40,
+        "0000000000000000aaaabbbbffffffff",
+        "00000000000000000000000000aaaabb" );
+      ( 64,
+        "01000000000000000000000000000000",
+        "00000000000000000100000000000000" );
+      ( 120,
+        "aaaabbbbccccdddd0000000000000000",
+        "000000000000000000000000000000aa" );
+      ( 127,
+        "80000000000000000000000000000000",
+        "00000000000000000000000000000001" );
+      ( 128,
+        "ffff0000000000000000000000000000",
+        "00000000000000000000000000000000" );
+    ]
   in
-  let assert_equal = assert_equal ~printer in
-  assert_equal ~msg:":: >> 32" (of_string "::")
-    (B128.shift_right (of_string_exn "::ffff:ffff") 32);
-  assert_equal ~msg:"::aaaa:bbbb:ffff:ffff >> 32" (of_string "::aaaa:bbbb")
-    (B128.shift_right (of_string_exn "::aaaa:bbbb:ffff:ffff") 32);
-  assert_equal ~msg:"::aaaa:bbbb:ffff:ffff >> 40" (of_string "::aa:aabb")
-    (B128.shift_right (of_string_exn "::aaaa:bbbb:ffff:ffff") 40);
-  assert_equal ~msg:"::ffff >> 2" (of_string "::3fff")
-    (B128.shift_right (of_string_exn "::ffff") 2);
-  assert_equal ~msg:"ffff:: >> 128" (of_string "::")
-    (B128.shift_right (of_string_exn "ffff::") 128);
-  assert_equal ~msg:"aaaa:bbbb:cccc:dddd:: >> 120" (of_string "::aa")
-    (B128.shift_right (of_string_exn "aaaa:bbbb:cccc:dddd::") 120);
-  assert_equal ~msg:"ffff:: >> 140"
-    (Error (`Msg "Ipaddr: unexpected argument sz (must be >= 0 and < 128)"))
-    (B128.shift_right (of_string_exn "ffff::") 140);
-  assert_equal ~msg:"::ffff:ffff >> -8"
-    (Error (`Msg "Ipaddr: unexpected argument sz (must be >= 0 and < 128)"))
-    (B128.shift_right (of_string_exn "::ffff:ffff") (-8))
+  List.iter
+    (fun (bits, input_value, expected_output) ->
+      assert_equal
+        ~msg:(Printf.sprintf "shift right by %i" bits)
+        (B128.of_string_exn expected_output)
+        (B128.shift_right (B128.of_string_exn input_value) bits))
+    test_shifts
 
-let suite = "Test B128 module" >::: [ "shift_right" >:: test_shift_right ];;
+let test_byte_module () =
+  let assert_equal = OUnit2.assert_equal ~printer:(Printf.sprintf "0x%x") in
+  assert_equal ~msg:"get 3 lsb" 0x00 (B128.Byte.get_lsbits 3 0x00);
+  assert_equal ~msg:"get 4 lsb" 0x0f (B128.Byte.get_lsbits 4 0xff);
+  assert_equal ~msg:"get 5 lsb" 0x10 (B128.Byte.get_lsbits 5 0x10);
+  assert_equal ~msg:"get 8 lsb" 0xff (B128.Byte.get_lsbits 8 0xff);
+
+  assert_equal ~msg:"get 3 msb" 0x0 (B128.Byte.get_msbits 3 0x00);
+  assert_equal ~msg:"get 4 msb" 0xf (B128.Byte.get_msbits 4 0xff);
+  assert_equal ~msg:"get 5 msb" 0x2 (B128.Byte.get_msbits 5 0x10);
+  assert_equal ~msg:"get 8 msb" 0xff (B128.Byte.get_msbits 8 0xff);
+
+  assert_equal ~msg:"set 3 msb" 0x20 (B128.Byte.set_msbits 3 0x1 0x00);
+  assert_equal ~msg:"set 4 msb" 0xa0 (B128.Byte.set_msbits 4 0xa 0x00);
+  assert_equal ~msg:"set 5 msb" 0x98 (B128.Byte.set_msbits 5 0x13 0x00);
+  assert_equal ~msg:"set 8 msb" 0xff (B128.Byte.set_msbits 8 0xff 0x00)
+
+let suite =
+  "Test B128 module"
+  >::: [
+         "addition" >:: test_addition;
+         "subtraction" >:: test_subtraction;
+         "of_to_string" >:: test_of_to_string;
+         "lognot" >:: test_lognot;
+         "shift_left" >:: test_shift_left;
+         "shift_right" >:: test_shift_right;
+         "byte_module" >:: test_byte_module;
+       ]
+;;
 
 let _results = run_test_tt_main suite in
 ()

--- a/lib_test/test_ipaddr_b128.ml
+++ b/lib_test/test_ipaddr_b128.ml
@@ -61,8 +61,8 @@ let test_subtraction () =
   let d3 = B128.of_string_exn "000000000000000000000000000002d6" in
   assert_equal ~msg:"test subtraction carry over" d3 (B128.sub_exn d1 d2);
 
-  (* subtracting one from min_int overflows *)
-  let d1 = B128.min_int () in
+  (* subtracting one from zero overflows *)
+  let d1 = B128.zero () in
   let d2 = B128.of_string_exn "00000000000000000000000000000001" in
   assert_raises ~msg:"subtracting one from min_int overflows" B128.Overflow
     (fun () -> B128.sub_exn d1 d2)


### PR DESCRIPTION
* this PR is a proposal to addresses issue #16
* I didn't touch any parsing functions, but migrated auxiliary functions to operate on Bytes. If this was over the top, I could cut this PR down to the essential parts and keep the rest for later.
* I've resorted to imperative code due to the index based set functions of Bytes