### PR TITLE
V4.compare: use Int32.unsigned_compare

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -112,7 +112,6 @@ module V4 = struct
   type t = int32
 
   let compare = Int32.unsigned_compare
-
   let make a b c d = ~|a <! 24 ||| (~|b <! 16) ||| (~|c <! 8 ||| (~|d <! 0))
 
   (* parsing *)

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -111,10 +111,7 @@ let reject_octal s i =
 module V4 = struct
   type t = int32
 
-  let compare a b =
-    (* ignore the sign *)
-    let c = Int32.compare (a >|> 1) (b >|> 1) in
-    if c = 0 then Int32.compare (a &&& 1l) (b &&& 1l) else c
+  let compare = Int32.unsigned_compare
 
   let make a b c d = ~|a <! 24 ||| (~|b <! 16) ||| (~|c <! 8 ||| (~|d <! 0))
 


### PR DESCRIPTION
Int32.unsigned_compare has been available since OCaml 4.08. Since this is the lower bound anyway we might as well use it instead of reimplementing it ourselves.