### PR TITLE
Use string for 128 bit integers (IPv6 addresses)

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -498,9 +498,8 @@ end = struct
   type t = string
 
   let mk_zero () = Bytes.make 16 '\x00'
-  let mk_max_int () = Bytes.make 16 '\xff'
   let zero = Bytes.unsafe_to_string (mk_zero ())
-  let max_int = Bytes.unsafe_to_string (mk_max_int ())
+  let max_int = String.make 16 '\xff'
   let compare = String.compare
   let equal = String.equal
   let fold_left f = String.fold_left (fun acc c -> f acc (Char.code c))
@@ -640,7 +639,7 @@ end = struct
       !a'
   end
 
-  let shift_right (x : string) n : string =
+  let shift_right x n =
     match n with
     | 0 -> x
     | 128 -> zero

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -502,6 +502,7 @@ end = struct
   let max_int = String.make 16 '\xff'
   let compare = String.compare
   let equal = String.equal
+
   let fold_left f init s =
     (* With OCaml>=4.13.0:
        [String.fold_left (fun acc c -> f acc (Char.code c)) init s] *)

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -530,7 +530,7 @@ end = struct
     Bytes.set_int64_be b' 8 b;
     Bytes.unsafe_to_string b'
 
-  let to_int64 b = (String.get_int64_be b 0, String.get_int64_be b 8)
+  let to_int64 s = (String.get_int64_be s 0, String.get_int64_be s 8)
 
   let of_int32 (a, b, c, d) =
     let b' = mk_zero () in
@@ -540,11 +540,11 @@ end = struct
     Bytes.set_int32_be b' 12 d;
     Bytes.unsafe_to_string b'
 
-  let to_int32 b =
-    ( String.get_int32_be b 0,
-      String.get_int32_be b 4,
-      String.get_int32_be b 8,
-      String.get_int32_be b 12 )
+  let to_int32 s =
+    ( String.get_int32_be s 0,
+      String.get_int32_be s 4,
+      String.get_int32_be s 8,
+      String.get_int32_be s 12 )
 
   let of_int16 (a, b, c, d, e, f, g, h) =
     let b' = mk_zero () in
@@ -558,15 +558,15 @@ end = struct
     Bytes.set_uint16_be b' 14 h;
     Bytes.unsafe_to_string b'
 
-  let to_int16 b =
-    ( String.get_uint16_be b 0,
-      String.get_uint16_be b 2,
-      String.get_uint16_be b 4,
-      String.get_uint16_be b 6,
-      String.get_uint16_be b 8,
-      String.get_uint16_be b 10,
-      String.get_uint16_be b 12,
-      String.get_uint16_be b 14 )
+  let to_int16 s =
+    ( String.get_uint16_be s 0,
+      String.get_uint16_be s 2,
+      String.get_uint16_be s 4,
+      String.get_uint16_be s 6,
+      String.get_uint16_be s 8,
+      String.get_uint16_be s 10,
+      String.get_uint16_be s 12,
+      String.get_uint16_be s 14 )
 
   let add_exn x y =
     let b = mk_zero () in
@@ -695,14 +695,14 @@ end = struct
       raise (Parse_error ("larger including offset than target bytes", s))
     else Bytes.blit_string s 0 dest off (String.length s)
 
-  let succ_exn b = add_exn b (of_int64 (0L, 1L))
+  let succ_exn x = add_exn x (of_int64 (0L, 1L))
 
-  let succ b =
-    try Ok (succ_exn b)
+  let succ x =
+    try Ok (succ_exn x)
     with Overflow -> Error (`Msg "Ipaddr: highest address has been reached")
 
-  let pred b =
-    try Ok (pred_exn b)
+  let pred x =
+    try Ok (pred_exn x)
     with Overflow | Invalid_argument _ ->
       Error (`Msg "Ipaddr: lowest address has been reached")
 end

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -502,7 +502,14 @@ end = struct
   let max_int = String.make 16 '\xff'
   let compare = String.compare
   let equal = String.equal
-  let fold_left f = String.fold_left (fun acc c -> f acc (Char.code c))
+  let fold_left f init s =
+    (* With OCaml>=4.13.0:
+       [String.fold_left (fun acc c -> f acc (Char.code c)) init s] *)
+    let a = ref init in
+    for i = 0 to 15 do
+      a := f !a (String.get_uint8 s i)
+    done;
+    !a
 
   let iteri_right2 f x y =
     for i = 15 downto 0 do

--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -463,11 +463,7 @@ module S128 : sig
   val equal : t -> t -> bool
   val fold_left : ('a -> int -> 'a) -> 'a -> t -> 'a
   val of_octets_exn : string -> t
-  val of_string_exn : string -> t
-  [@@ocaml.warning "-32"]
   val to_octets : t -> string
-  val to_string : t -> string
-  [@@ocaml.warning "-32"]
   val of_int64 : int64 * int64 -> t
   val to_int64 : t -> int64 * int64
   val of_int32 : int32 * int32 * int32 * int32 -> t
@@ -501,13 +497,6 @@ module S128 : sig
   val pred : t -> (t, [> `Msg of string ]) result
 end
 = struct
-  let int_of_hex_char c =
-    match c with
-    | '0' .. '9' -> Char.code c - 48
-    | 'a' .. 'f' -> Char.code c - 87
-    | 'A' .. 'F' -> Char.code c - 55
-    | _ -> invalid_arg "char is not a valid hex digit"
-
   exception Overflow
 
   type t = string
@@ -533,23 +522,7 @@ end
     if String.length s <> 16 then invalid_arg "not 16 bytes long";
     s
 
-  let of_string_exn s =
-    if String.length s <> 32 then invalid_arg "not 32 chars long";
-    Bytes.init 16
-      (fun bi ->
-         let i = bi * 2 in
-         let x = int_of_hex_char s.[i+1] and y = int_of_hex_char s.[i] in
-         char_of_int ((y lsl 4) + x))
-    |> Bytes.unsafe_to_string
-
   let to_octets = Fun.id
-
-  let to_string b =
-    List.init 16
-      (fun i -> Printf.sprintf "%.2x" (String.get_uint8 b i))
-    |> String.concat ""
-    [@@ocaml.warning "-32"]
-  (* used in the tests *)
 
   let of_int64 (a, b) =
     let b' = mk_zero () in
@@ -720,7 +693,7 @@ end
            ("larger including offset than target bytes", s))
     else Bytes.blit_string s 0 dest off (String.length s)
 
-  let succ_exn b = add_exn b (of_string_exn "00000000000000000000000000000001")
+  let succ_exn b = add_exn b (of_int64 (0L, 1L))
 
   let succ b =
     try Ok (succ_exn b)

--- a/lib/ipaddr_cstruct.ml
+++ b/lib/ipaddr_cstruct.ml
@@ -47,22 +47,14 @@ module V6 = struct
   let of_cstruct_exn cs =
     let len = Cstruct.length cs in
     if len < 16 then raise (need_more (Cstruct.to_string cs));
-    let hihi = Cstruct.BE.get_uint32 cs 0 in
-    let hilo = Cstruct.BE.get_uint32 cs 4 in
-    let lohi = Cstruct.BE.get_uint32 cs 8 in
-    let lolo = Cstruct.BE.get_uint32 cs 12 in
-    of_int32 (hihi, hilo, lohi, lolo)
+    of_octets_exn (Cstruct.to_string ~len:16 cs)
 
   let of_cstruct cs = try_with_result of_cstruct_exn cs
 
   let write_cstruct_exn i cs =
     let len = Cstruct.length cs in
     if len < 16 then raise (need_more (Cstruct.to_string cs));
-    let a, b, c, d = to_int32 i in
-    Cstruct.BE.set_uint32 cs 0 a;
-    Cstruct.BE.set_uint32 cs 4 b;
-    Cstruct.BE.set_uint32 cs 8 c;
-    Cstruct.BE.set_uint32 cs 12 d
+    Cstruct.blit_from_string (to_octets i) 0 cs 0 16
 
   let to_cstruct ?(allocator = Cstruct.create) i =
     let cs = allocator 16 in

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -681,7 +681,7 @@ module Test_v6 = struct
       "\000\000\000\000\000\000\000\000\000\000\255\255\192\168\000\001"
     in
     let v6 = V6.of_octets_exn addr in
-    assert_equal ~msg:(String.escaped addr) V6.(to_octets v6) addr
+    assert_equal ~printer:String.escaped ~msg:(String.escaped addr) V6.(to_octets v6) addr
 
   let test_bytes_rt_bad () =
     let addrs =

--- a/lib_test/test_ipaddr.ml
+++ b/lib_test/test_ipaddr.ml
@@ -681,7 +681,9 @@ module Test_v6 = struct
       "\000\000\000\000\000\000\000\000\000\000\255\255\192\168\000\001"
     in
     let v6 = V6.of_octets_exn addr in
-    assert_equal ~printer:String.escaped ~msg:(String.escaped addr) V6.(to_octets v6) addr
+    assert_equal ~printer:String.escaped ~msg:(String.escaped addr)
+      V6.(to_octets v6)
+      addr
 
   let test_bytes_rt_bad () =
     let addrs =

--- a/lib_test/test_ipaddr_b128.ml
+++ b/lib_test/test_ipaddr_b128.ml
@@ -16,7 +16,7 @@
  *)
 
 open OUnit
-module B128 = Ipaddr_internal.B128
+module B128 = Ipaddr_internal.S128
 
 (* copied from test_ipaddr.ml *)
 let assert_raises ~msg exn test_fn =
@@ -28,11 +28,11 @@ let assert_raises ~msg exn test_fn =
           Printexc.print_backtrace stderr);
         raise rtexn)
 
-let assert_equal = assert_equal ~printer:Ipaddr_internal.B128.to_string
+let assert_equal = assert_equal ~printer:Ipaddr_internal.S128.to_string
 
 let test_addition () =
   (* simple addition *)
-  let d1 = B128.zero () in
+  let d1 = B128.zero in
   let d2 = B128.of_string_exn "00000000000000000000000000000001" in
   assert_equal ~msg:"adding one to zero is one" d2 (B128.add_exn d1 d2);
 
@@ -43,29 +43,25 @@ let test_addition () =
   assert_equal ~msg:"test addition carry over" d3 (B128.add_exn d1 d2);
 
   (* adding one to max_int overflows *)
-  let d1 = B128.max_int () in
+  let d1 = B128.max_int in
   let d2 = B128.of_string_exn "00000000000000000000000000000001" in
   assert_raises ~msg:"adding one to max_int overflows" B128.Overflow (fun () ->
       B128.add_exn d1 d2)
 
-let test_subtraction () =
+let test_pred () =
   (* simple subtraction *)
   let d1 = B128.of_string_exn "00000000000000000000000000000001" in
-  let d2 = B128.of_string_exn "00000000000000000000000000000001" in
-  let d3 = B128.zero () in
-  assert_equal ~msg:"subtracting one from one is zero" d3 (B128.sub_exn d1 d2);
+  let d2 = B128.zero in
+  assert_equal ~msg:"subtracting one from one is zero" d2 (B128.pred_exn d1);
 
   (* subtract carry *)
   let d1 = B128.of_string_exn "00000000000000000000000000000300" in
-  let d2 = B128.of_string_exn "0000000000000000000000000000002a" in
-  let d3 = B128.of_string_exn "000000000000000000000000000002d6" in
-  assert_equal ~msg:"test subtraction carry over" d3 (B128.sub_exn d1 d2);
+  let d2 = B128.of_string_exn "000000000000000000000000000002ff" in
+  assert_equal ~msg:"test subtraction carry over" d2 (B128.pred_exn d1);
 
   (* subtracting one from zero overflows *)
-  let d1 = B128.zero () in
-  let d2 = B128.of_string_exn "00000000000000000000000000000001" in
   assert_raises ~msg:"subtracting one from min_int overflows" B128.Overflow
-    (fun () -> B128.sub_exn d1 d2)
+    (fun () -> B128.pred_exn B128.zero)
 
 let test_of_to_string () =
   let s = "ff000000000000004200000000000001" in
@@ -169,7 +165,7 @@ let suite =
   "Test B128 module"
   >::: [
          "addition" >:: test_addition;
-         "subtraction" >:: test_subtraction;
+         "pred" >:: test_pred;
          "of_to_string" >:: test_of_to_string;
          "lognot" >:: test_lognot;
          "shift_left" >:: test_shift_left;

--- a/lib_test/test_ipaddr_b128.ml
+++ b/lib_test/test_ipaddr_b128.ml
@@ -37,17 +37,15 @@ let int_of_hex_char c =
 
 let to_string (s : Ipaddr_internal.S128.t) =
   let s : string = Obj.magic s in
-  List.init 16
-    (fun i -> Printf.sprintf "%.2x" (String.get_uint8 s i))
+  List.init 16 (fun i -> Printf.sprintf "%.2x" (String.get_uint8 s i))
   |> String.concat ""
 
 let of_string_exn s : B128.t =
   if String.length s <> 32 then invalid_arg "not 32 chars long";
-  Bytes.init 16
-    (fun bi ->
-       let i = bi * 2 in
-       let x = int_of_hex_char s.[i+1] and y = int_of_hex_char s.[i] in
-       char_of_int ((y lsl 4) + x))
+  Bytes.init 16 (fun bi ->
+      let i = bi * 2 in
+      let x = int_of_hex_char s.[i + 1] and y = int_of_hex_char s.[i] in
+      char_of_int ((y lsl 4) + x))
   |> Bytes.unsafe_to_string
   |> Obj.magic
 


### PR DESCRIPTION
The interface of `B128` introduced in #115  is functional in that the arguments to its functions are not mutated. This PR replaces `B128` with a module `S128` that internally uses `Bytes.t` but externally operates on `string`s. Furhermore, 
- the type `S128.t` is made abstract with a signature for `S128`,
- some functions only used in tests are moved to the relevant tests, and
- `sub_exn` is replaced by `pred_exn` as the only usage of `sub_exn` was subtracting one.