### PR TITLE
add Ipaddr.Prefix.address

### DIFF
--- a/lib/ipaddr.ml
+++ b/lib/ipaddr.ml
@@ -1354,6 +1354,10 @@ module Prefix = struct
     | V4 p -> V4 (V4.Prefix.netmask p)
     | V6 p -> V6 (V6.Prefix.netmask p)
 
+  let address = function
+    | V4 p -> V4 (V4.Prefix.address p)
+    | V6 p -> V6 (V6.Prefix.address p)
+
   let pp ppf i = Format.fprintf ppf "%s" (to_string i)
 
   let first = function

--- a/lib/ipaddr.mli
+++ b/lib/ipaddr.mli
@@ -777,6 +777,9 @@ module Prefix : sig
   val netmask : t -> addr
   (** [netmask subnet] is the netmask for [subnet]. *)
 
+  val address : t -> addr
+  (** [address cidr] is the address for [cidr]. *)
+
   val first : t -> addr
   (** [first subnet] is first valid unicast address in this [subnet]. *)
 


### PR DESCRIPTION
previously only Ipaddr.V4.Prefix.address and Ipaddr.V6.Prefix.address were available. it is pretty useful to also extract an IP address from an Ipaddr.Prefix.t